### PR TITLE
CB-5316 Spell Cordova as a brand unless it's a command or script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coho",
   "version": "0.0.2",
-  "description": "apache cordova release tool",
+  "description": "Apache Cordova release tool",
   "main": "./coho",
   "bin": {
     "coho": "./coho"


### PR DESCRIPTION
Please note that this is a proposal. If you have comments about the general proposal, please comment in the JIRA issue, thanks.

Yes, Apache isn't really part of spelling Cordova correctly, but it suffered from being _in the neighborhood_
