### PR TITLE
Spelling: release

### DIFF
--- a/coho
+++ b/coho
@@ -775,7 +775,7 @@ function apacheUpload(){
             '    Checking out Apache Cordova release repository if it does not already exist.\n' +
             '    Updating the repositoryvia svn update\n' +
             '    Optionally removing old release artifacts\n' +
-            '    Copying in new relase artifacts\n' +
+            '    Copying in new release artifacts\n' +
             '    Svn committing new release artifacts to the apache repo\n' +
             '\n' +
             'Usage: $0 upload-release --new-version 3.0.0 [--prev-version 2.9.0]')


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6189

This commit should be squished before [rebase/cherrypick] merging (and include CB-6189 in the commit message)

Commits are sorted into categories and arranged by stems.

Note that acknowledgment is misspelled in a LICENSE file, but that's from an upstream which would need to be contacted (someone is encouraged to do so...)
