### PR TITLE
CB-7309 Coho. verify-archive incorrectly parses hash output on Windows

### DIFF
--- a/src/create-verify-archive.js
+++ b/src/create-verify-archive.js
@@ -139,5 +139,5 @@ function *computeHash(path, algo) {
 }
 
 function extractHashFromOutput(output) {
-    return output.replace(/.*?:/, '').replace(/\s*/g, '').toLowerCase();
+    return output.slice(output.lastIndexOf(':') + 1).replace(/\s*/g, '').toLowerCase();
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-7309
