### PR TITLE
Initial coho handling for the new cordova-serve module in cordova-lib.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 apache-rat-0.8
 apache-rat-0.10
 node_modules
+.idea

--- a/src/create-verify-archive.js
+++ b/src/create-verify-archive.js
@@ -75,7 +75,7 @@ exports.createCommand = function*(argv) {
     var absOutDir = path.resolve(outDir);
 
     yield repoutil.forEachRepo(repos, function*(repo) {
-        var tag = argv.tag || (yield gitutil.findMostRecentTag());
+        var tag = argv.tag || (yield gitutil.findMostRecentTag(repo.versionPrefix));
         if (!tag) {
             apputil.fatal('Could not find most recent tag. Try running with --tag');
         }

--- a/src/print-tags.js
+++ b/src/print-tags.js
@@ -44,7 +44,7 @@ module.exports = function*(argv) {
         if (argv.tag){
             tag = argv.tag;
         } else {
-            tag = yield gitutil.findMostRecentTag();
+            tag = yield gitutil.findMostRecentTag(repo.versionPrefix);
         }
         if (!tag) {
             console.log('    ' + repo.repoName + ': NO TAGS');

--- a/src/repoutil.js
+++ b/src/repoutil.js
@@ -363,6 +363,11 @@ var toolRepos = [
             'platformsConfig.json'
         ]
     }, {
+        title: 'Cordova Serve',
+        id: 'serve',
+        repoName: 'cordova-lib',
+        versionPrefix: 'serve'
+    }, {
         title: 'Cordova JS',
         id: 'js',
         repoName: 'cordova-js',
@@ -484,8 +489,8 @@ exports.forEachRepo = function*(repos, func) {
         // TODO: rely less on process.cwd()
         isInForEachRepoFunction = true;
 
-        //cordova-lib lives inside of a top level cordova-lib directory
-        if(repo.id === 'lib'){
+        //cordova-lib and cordova-serve live inside of a top level cordova-lib directory
+        if(repo.id === 'lib' || repo.id === 'serve'){
             origPath = origPath + '/..';
         }
         var repoDir = getRepoDir(repo);
@@ -524,6 +529,8 @@ function getRepoDir(repo) {
     var repoDir = path.join(baseWorkingDir, repo.repoName);
     if(repo.id === 'lib'){
         repoDir = path.join(repoDir, 'cordova-lib');
+    } else if(repo.id === 'serve') {
+        repoDir = path.join(repoDir, 'cordova-serve');
     }
     return repoDir;
 }


### PR DESCRIPTION
1. Adds `cordova-serve` as another "repo" in coho's list of repos (it actually just points to the `cordova-lib` repo, but allows various command to work directly on `cordova-serve`).
2. Adds the ability to work with prefixed tags, so `cordova-serve` can maintain versions independent of `cordova-lib`.

Note that this introduces `cordova-serve` as another "repo" as far as coho is concerned, which I think works ok for now. But ultimately, particularly if we introduce more modules in the `cordova-lib` repo, we should probably add to coho the concept of "modules" or "packages" within repos (so `cordova-serve` would not exist as a separate "repo" in coho's list of repos, but as a module within the `cordova-lib` repo, alongside the `cordova-lib` module) - then, among other benefits, we can provide generic handling for the fact that modules live within sub-directories of their repo (rather than the custom handling we have now).