### PR TITLE
Handle multiple modules within a single repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 apache-rat-0.8
 apache-rat-0.10
 node_modules
+.idea

--- a/src/audit-license-headers.js
+++ b/src/audit-license-headers.js
@@ -58,7 +58,7 @@ module.exports = function*() {
         optimist.showHelp();
         process.exit(1);
     }
-    var repos = flagutil.computeReposFromFlag(argv.r);
+    var repos = flagutil.computeReposFromFlag(argv.r, {includeModules: true});
     // Check that RAT command exists.
     var ratName = 'apache-rat-0.10';
     var ratUrl = "https://dist.apache.org/repos/dist/release/creadur/apache-rat-0.10/apache-rat-0.10-bin.tar.gz";

--- a/src/create-verify-archive.js
+++ b/src/create-verify-archive.js
@@ -64,7 +64,7 @@ exports.createCommand = function*(argv) {
         optimist.showHelp();
         process.exit(1);
     }
-    var repos = flagutil.computeReposFromFlag(argv.r);
+    var repos = flagutil.computeReposFromFlag(argv.r, {includeModules: true});
 
     if (argv.sign && !shelljs.which('gpg')) {
         apputil.fatal('gpg command not found on your PATH. Refer to ' + settingUpGpg);
@@ -75,7 +75,7 @@ exports.createCommand = function*(argv) {
     var absOutDir = path.resolve(outDir);
 
     yield repoutil.forEachRepo(repos, function*(repo) {
-        var tag = argv.tag || (yield gitutil.findMostRecentTag());
+        var tag = argv.tag || (yield gitutil.findMostRecentTag(repo.versionPrefix));
         if (!tag) {
             apputil.fatal('Could not find most recent tag. Try running with --tag');
         }

--- a/src/gitutil.js
+++ b/src/gitutil.js
@@ -22,21 +22,42 @@ var executil = require('./executil');
 var gitutil = exports;
 var semver = require('semver');
 
-exports.findMostRecentTag = function*() {
-    // Returns the greatest semver-looking tag in the repo
+/**
+ * Returns the greatest semver-looking tag in the repo. If prefix is specified, only looks at tags that start with
+ * 'prefix-' (this allows for multiple modules in the same repo).
+ * @param {string} [prefix] - An optional prefix to filter tags.
+ * @returns {string} - the most recent tag, or null if no version tags are found.
+ */
+exports.findMostRecentTag = function*(prefix) {
+    prefix = prefix && prefix + "-";
+
     return (yield executil.execHelper(executil.ARGS('git tag --list'), true)).split(/\s+/)
-    .reduce(function(curBest, value) {
-        // Strip the "r" prefix that plugin repos use (ugh), but also make them look higher than 3.0.0 tag that exists
-        var modifiedCurBest = curBest.replace(/^r/, '9');
-        var modifiedValue = value.replace(/^r/, '9');
-        if (semver.valid(modifiedValue)) {
-            return !curBest ? modifiedValue : semver.gt(modifiedCurBest, modifiedValue) ? curBest : value;
-        } else if (curBest && semver.valid(modifiedCurBest)) {
-            return curBest;
-        }
-        return null;
-    });
-}
+        .reduce(function (curBest, value) {
+            var modifiedCurBest, modifiedValue;
+
+            if (prefix) {
+                // Ignore values that don't start with prefix, and strip prefix from the value we're going to test
+                if (value.indexOf(prefix) !== 0) {
+                    modifiedValue = null;
+                    modifiedCurBest = null;
+                } else {
+                    modifiedValue = value.substr(prefix.length);
+                    modifiedCurBest = curBest && curBest.substr(prefix.length);
+                }
+            } else {
+                // Strip the "r" prefix that plugin repos use (ugh), but also make them look higher than 3.0.0 tag that exists
+                modifiedCurBest = curBest.replace(/^r/, '9');
+                modifiedValue = value.replace(/^r/, '9');
+            }
+
+            if (semver.valid(modifiedValue)) {
+                return !curBest ? value : semver.gt(modifiedCurBest, modifiedValue) ? curBest : value;
+            } else if (curBest && semver.valid(modifiedCurBest)) {
+                return curBest;
+            }
+            return null;
+        });
+};
 
 exports.tagExists = function*(tagName) {
     return !!(yield executil.execHelper(executil.ARGS('git tag --list ' + tagName), true));

--- a/src/last-week.js
+++ b/src/last-week.js
@@ -54,7 +54,7 @@ module.exports = function*() {
         optimist.showHelp();
         process.exit(1);
     }
-    var repos = flagutil.computeReposFromFlag(argv.r);
+    var repos = flagutil.computeReposFromFlag(argv.r, {includeModules: true});
     var filterByEmail = !!argv.me || !! argv.user;
     var days = argv.days || 7;
     var userEmail = filterByEmail && (argv.user || meEmail);
@@ -78,7 +78,7 @@ module.exports = function*() {
             format += ' %an - ';
         }
         format += '%cd %s';
-        var output = yield executil.execHelper(cmd.concat([format, '--since=' + days + ' days ago']), true);
+        var output = yield executil.execHelper(cmd.concat([format, '--since=' + days + ' days ago']).concat(repoutil.getRepoIncludePath(repo)), true);
         if (output) {
             console.log(output);
             commitCount += output.split('\n').length;
@@ -91,7 +91,7 @@ module.exports = function*() {
         yield repoutil.forEachRepo(repos, function*(repo) {
             var repoName = repo.id + new Array(Math.max(0, 20 - repo.id.length + 1)).join(' ');
             var output = yield executil.execHelper(cmd.concat(['--format=%ae|' + repoName + ' %cd %s',
-                '--since=' + days + ' days ago']), true);
+                '--since=' + days + ' days ago']).concat(repoutil.getRepoIncludePath(repo)), true);
             if (output) {
                 output.split('\n').forEach(function(line) {
                     line = line.replace(/(.*?)\|/, '');

--- a/src/main.js
+++ b/src/main.js
@@ -113,6 +113,10 @@ module.exports = function() {
             desc: 'Publishes current version of repo to specified tag',
             entryPoint: lazyRequire('./npm-publish', 'publishTag')
         }, {
+            name: 'update-release-notes',
+            desc: 'Updates release notes with commits since the most recent tag.',
+            entryPoint: lazyRequire('./update-release-notes')
+        },  {
             name: 'npm-unpublish-nightly',
             desc: 'Unpublishes last nightly versions for cli and lib',
             entryPoint: lazyRequire('./npm-publish', 'unpublishNightly')

--- a/src/print-tags.js
+++ b/src/print-tags.js
@@ -37,14 +37,14 @@ module.exports = function*(argv) {
         optimist.showHelp();
         process.exit(1);
     }
-    var repos = flagutil.computeReposFromFlag(argv.r);
+    var repos = flagutil.computeReposFromFlag(argv.r, {includeModules: true});
 
     var tag;
     yield repoutil.forEachRepo(repos, function*(repo) {
         if (argv.tag){
             tag = argv.tag;
         } else {
-            tag = yield gitutil.findMostRecentTag();
+            tag = yield gitutil.findMostRecentTag(repo.versionPrefix);
         }
         if (!tag) {
             console.log('    ' + repo.repoName + ': NO TAGS');

--- a/src/repo-clone.js
+++ b/src/repo-clone.js
@@ -40,7 +40,7 @@ module.exports = function*(argv) {
 
     var depth = argv.depth ? argv.depth : null;
 
-    var repos = flagutil.computeReposFromFlag(argv.r, true);
+    var repos = flagutil.computeReposFromFlag(argv.r, {includeSvn: true});
     yield cloneRepos(repos, false, depth);
 }
 

--- a/src/update-release-notes.js
+++ b/src/update-release-notes.js
@@ -1,0 +1,65 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+var fs = require('fs');
+var path = require('path');
+var optimist = require('optimist');
+var executil = require('./executil');
+var flagutil = require('./flagutil');
+var gitutil = require('./gitutil');
+var repoutil = require('./repoutil');
+
+module.exports = function*() {
+    var meEmail = yield executil.execHelper(executil.ARGS('git config user.email'), true);
+    var opt = flagutil.registerRepoFlag(optimist);
+    opt = flagutil.registerHelpFlag(opt)
+        .usage('Updates release notes with commits since the most recent tag.\n' +
+        '\n' +
+        'Usage: $0 update-release-notes [--repo=ios]');
+    argv = opt.argv;
+
+    if (argv.h) {
+        optimist.showHelp();
+        process.exit(1);
+    }
+
+    var repos = flagutil.computeReposFromFlag(argv.r, {includeModules: true});
+
+    var cmd = executil.ARGS('git log --topo-order --no-merges');
+    cmd.push(['--pretty=format:* %s']);
+    yield repoutil.forEachRepo(repos, function*(repo) {
+        var tag = yield gitutil.findMostRecentTag(repo.versionPrefix);
+        cmd.push(tag + '..master');
+        var repoDesc = repo.repoName;
+        if (repo.path) {
+            repoDesc += '/' + repo.path;
+        }
+        console.log('Finding commits in ' + repoDesc + ' since tag ' + tag);
+        var output = yield executil.execHelper(cmd.concat(repoutil.getRepoIncludePath(repo)), true);
+        if (output) {
+            var newVersion = require(path.join(process.cwd(), 'package.json')).version;
+            var relNotesFile = 'RELEASENOTES.md';
+            var data = fs.readFileSync(relNotesFile, {encoding: 'utf8'});
+            var pos = data.indexOf('### ');
+            var date = new Date().toDateString().split(' ');
+            data = data.substr(0, pos) + "### " + newVersion + ' (' + date[1] + ' ' + date[2] + ', ' + date[3] + ')\n' + output + '\n\n' + data.substr(pos);
+            fs.writeFileSync(relNotesFile, data, {encoding: 'utf8'});
+        }
+    });
+};


### PR DESCRIPTION
This change includes logic to handle multiple modules within a single repo, and adds specific handling for the `cordova-serve` module in the `cordova-lib` repo. It also generalizes some of the existing logic for modules within a repo (that formerly was specific to `cordova-lib`). Specific changes:

1. Adds support for repos specifying a path to their module, when it is not at the top level.
2. Adds support for a repo entry actually being a module within a repo.
3. Adds `Cordova Serve` to the list of repos, it actually being a module within the `Cordova Lib` repo.
4. When calling `computeReposFromFlag()`, the caller can request to just get repos (the default) or to get modules. If just repos, then where the list would include two entries that point to the same repo, only one is returned (the 'base' module is prioritized). When modules are requested, then all entries are returned. The idea here is that actions that work on repos only want unique repos. Actions that work on modules (like packaging, license checks etc) want modules.
5. The following repo based commands now work on modules:
  * `audit-license-headers`
  * `check-license`
  * `create-archive`
  * `last-week`
  * `print-tags`
6. `findMostRecentTag()` can now be provided a prefix, in which case it will find the most recent tag with that prefix. The prefix can be used by modules other than the primary module to differentiate their versions.
7. Added `update-release-notes` command that will update a module's release notes picking commits that are unique to the module's path (see `repoutil.getRepoIncludePath()`)
8. Added `repoutil.getRepoIncludePath()` method that determines a path to provide `git log` so it only includes commits unique to a module. For the base module, this will include commits in the root directory and the base module's directory. For other modules, it will only include changes in the module's directory.