### PR TITLE
CB-9585 Support globs with 'coho verify-archive' command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "chalk": "~0.4",
     "co": "~3.0",
+    "glob": "^5.0.14",
     "gnode": "^0.1.0",
     "nlf": "1.1.0",
     "opener": "^1.4.1",


### PR DESCRIPTION
This adds supports for globs to the `coho verify-archive` command, so you can pass wildcards such as:

    coho verify-archive *.tgz

(which is handy, since that's what `coho create-archive` says to do :smile:).