### PR TITLE
CB-7904 Built nightly releases using coho

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -121,7 +121,7 @@ module.exports = function() {
         },  {
             name: 'npm-unpublish-nightly',
             desc: 'Unpublishes last nightly versions for cli and lib',
-            entryPoint: lazyRequire('./npm-publish', 'unpublishNightly')
+            entryPoint: lazyRequire('./npm-publish', 'unpublish')
         }];
     var otherCommands = [{
             name: 'list-pulls',

--- a/src/npm-link.js
+++ b/src/npm-link.js
@@ -57,7 +57,9 @@ function *createLink(argv) {
 
     npmLinkOut("cordova-common");
     npmLinkIn("cordova-common", "cordova-lib");
-    npmLinkIn("cordova-common", "cordova-android");
+
+    npmLinkOut("cordova-fetch");
+    npmLinkIn("cordova-fetch", "cordova-lib");
 
     npmLinkOut("cordova-lib");
     npmLinkIn("cordova-lib", "cordova-plugman");
@@ -67,7 +69,10 @@ function *createLink(argv) {
 module.exports = createLink;
 
 function getPathFromModuleName(moduleName) {
-    if (moduleName == "cordova-lib" || moduleName == "cordova-common") {
+    if (moduleName == "cordova-lib" ||
+        moduleName == "cordova-common" ||
+        moduleName == "cordova-fetch") {
+
         return("cordova-lib" + path.sep + moduleName);
     }
 

--- a/src/retrieve-sha.js
+++ b/src/retrieve-sha.js
@@ -22,7 +22,7 @@ var executil = require('./executil');
 module.exports = function *(repos) {
     var shas = {};
     yield repoutil.forEachRepo(repos, function*(repo) {
-        shas[repo.id] = yield executil.execHelper(executil.ARGS('git rev-parse HEAD'), true, true);
+        shas[repo.id] = yield executil.execHelper(executil.ARGS('git rev-parse --short=8 HEAD'), true, true);
     });
     return shas;
 }


### PR DESCRIPTION
CB-7904 Built nightly releases using coho

Updates code for the current version
Fixed the date format
Add 'ignore-test-failures' flag for debugging purposes
Clone repos if necessary before updating
Add lib commit SHA to the build version
Adds handling for separate CLI and LIB nightly versions unpublishing
Fixes npm-unpublish-nightly entryPoint

CB-9858 Implement Cordova Fetch Proposal

Ensure fetch and cli is properly installed/linked
Add fetch to list of tools repos
Resolve cordova-fetch location properly when npm-linking modules

[Jira issue](https://issues.apache.org/jira/browse/CB-7904)