### PR TITLE
CB-11279 Support arbitrary repositories for 'coho nightly'

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -120,8 +120,8 @@ module.exports = function() {
             entryPoint: lazyRequire('./update-release-notes')
         },  {
             name: 'npm-unpublish-nightly',
-            desc: 'Unpublishes last nightly versions for cli and lib',
-            entryPoint: lazyRequire('./npm-publish', 'unpublish')
+            desc: 'Unpublishes last nightly versions for all specified repositories',
+            entryPoint: lazyRequire('./npm-publish', 'unpublishNightly')
         }];
     var otherCommands = [{
             name: 'list-pulls',
@@ -137,7 +137,7 @@ module.exports = function() {
             desc: 'Launches github PR UI for the specified topic branch',
             entryPoint: lazyRequire('./create-pr'),
             noChdir : true
-        }, 
+        },
         {
             name: 'last-week',
             desc: 'Prints out git logs of things that happened last week.',

--- a/src/nightly.js
+++ b/src/nightly.js
@@ -101,27 +101,11 @@ module.exports = function*(argv) {
     var options = {};
     options.tag = 'nightly';
     options.pretend = argv.pretend;
+    options.r = reposToBuild.map(function (repo) { return repo.id; });
 
     //unpublish old nightly
-    yield repoutil.forEachRepo(reposToBuild, function*(repo) {
-        var packageName = repo.packageName || repo.repoName;
-        var oldNightlyVersion = yield executil.execHelper(executil.ARGS('npm view ' + packageName + ' dist-tags.nightly'), /*silent=*/true);
-
-        if (!oldNightlyVersion || oldNightlyVersion === 'undefined') {
-            apputil.print(packageName + ' is not yet published under @nightly tag. Skipping unpublish...');
-            return;
-        }
-
-        apputil.print('Latest ' + packageName + '@nightly version is ' + oldNightlyVersion);
-
-        options.r = [repo.id];
-        options.version = oldNightlyVersion;
-
-        yield npmpublish.unpublish(options);
-    });
-
+    yield npmpublish.unpublishNightly(options);
     //publish to npm under nightly tag
-    options.r = reposToBuild.map(function (repo) { return repo.id; });
     yield npmpublish.publishTag(options);
 };
 

--- a/src/nightly.js
+++ b/src/nightly.js
@@ -33,10 +33,11 @@ var npmlink = require('./npm-link');
 var repoclone = require('./repo-clone');
 
 module.exports = function*(argv) {
-    var repos = flagutil.computeReposFromFlag('tools');
-    var cli = repoutil.getRepoById('cli');
-    var cordovaLib = repoutil.getRepoById('lib');
+    /** Specifies the default repos to build nightlies for */
+    var DEFAULT_NIGHTLY_REPOS = ['cli', 'lib'];
+
     var opt = flagutil.registerHelpFlag(optimist);
+    opt = flagutil.registerRepoFlag(opt);
 
     argv = opt
         .usage('Publish CLI & LIB to NPM under nightly tag. \n' +
@@ -52,6 +53,7 @@ module.exports = function*(argv) {
             type:'boolean',
             alias : 'ignoreTestFailures'
         })
+        .default({ r: DEFAULT_NIGHTLY_REPOS})
         .argv;
 
     if(argv.h) {
@@ -60,36 +62,26 @@ module.exports = function*(argv) {
     }
 
     // Clone and update Repos
-    yield repoclone.cloneRepos(repos, /*silent=*/true);
-    yield repoupdate.updateRepos(repos);
+    yield prepareRepos(argv.r);
 
-    //remove local changes and sync up with remote master
-    yield repoutil.forEachRepo(repos, function*() {
-        yield gitutil.gitClean();
-        yield gitutil.resetFromOrigin();
-    });
+    var reposToBuild = flagutil.computeReposFromFlag(argv.r, { includeModules: true });
+    // Get updated nightly versions for all repos
+    /** @type {Object} A map of repo.id and a short SHA for every repo to build */
+    var VERSIONS = yield retrieveVersions(reposToBuild);
 
-    // Get SHAS from repos
-    var SHAJSON = yield retrieveSha(repos);
-
-    var currentDate = new Date();
-    var nightlyVersion = '-nightly.' + currentDate.getFullYear() + '.' +
-        (currentDate.getMonth() + 1) + '.' + currentDate.getDate();
-    var cordovaLibVersion;
     //update package.json version for cli + lib, update lib reference for cli
-    yield repoutil.forEachRepo([cordovaLib, cli], function*(repo) {
-        var dir = process.cwd();
-        var packageJSON = require(dir+'/package.json');
-        packageJSON.version = versionutil.removeDev(packageJSON.version) + nightlyVersion +
-            '+' + SHAJSON[repo.id];
+    yield repoutil.forEachRepo(reposToBuild, function*(repo) {
+        var packageJSONPath = path.join(process.cwd(), 'package.json');
+        var packageJSON = require(packageJSONPath);
 
-        if(repo.id === 'lib'){
-            cordovaLibVersion = packageJSON.version;
-        } else {
-            packageJSON.dependencies['cordova-lib'] = cordovaLibVersion;
-        }
+        // Update package version
+        apputil.print('Updating ' + repo.id + ' version to ' + VERSIONS[repo.id]);
+        packageJSON.version = VERSIONS[repo.id];
 
-        fs.writeFileSync(dir+'/package.json', JSON.stringify(packageJSON, null, 4), 'utf8', function(err) {
+        // If there is a dependencies listed, iterate through and update cordova-* dependencies
+        packageJSON.dependencies = mapDependenciesVersions(packageJSON.dependencies, VERSIONS);
+
+        fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 4), 'utf8', function(err) {
             if (err) return console.log (err);
         });
     });
@@ -98,21 +90,28 @@ module.exports = function*(argv) {
     yield npmlink();
 
     // npm install cli
+    var cli = repoutil.getRepoById('cli');
     yield repoutil.forEachRepo([cli], function*(repo) {
         yield executil.execHelper(executil.ARGS('npm install'), /*silent=*/true, false);
     });
 
     //run CLI + cordova-lib tests
-    yield runTests(cli, cordovaLib, argv.ignoreTestFailures);
+    yield runTests(reposToBuild, argv.ignoreTestFailures);
 
     var options = {};
     options.tag = 'nightly';
     options.pretend = argv.pretend;
 
     //unpublish old nightly
-    yield repoutil.forEachRepo([cordovaLib, cli], function*(repo) {
+    yield repoutil.forEachRepo(reposToBuild, function*(repo) {
         var packageName = repo.packageName || repo.repoName;
-        var oldNightlyVersion = yield executil.execHelper(executil.ARGS('npm view ' + packageName + ' dist-tags.nightly'));
+        var oldNightlyVersion = yield executil.execHelper(executil.ARGS('npm view ' + packageName + ' dist-tags.nightly'), /*silent=*/true);
+
+        if (!oldNightlyVersion || oldNightlyVersion === 'undefined') {
+            apputil.print(packageName + ' is not yet published under @nightly tag. Skipping unpublish...');
+            return;
+        }
+
         apputil.print('Latest ' + packageName + '@nightly version is ' + oldNightlyVersion);
 
         options.r = [repo.id];
@@ -121,13 +120,50 @@ module.exports = function*(argv) {
         yield npmpublish.unpublish(options);
     });
 
-    options.r = ['lib', 'cli'];
     //publish to npm under nightly tag
+    options.r = reposToBuild.map(function (repo) { return repo.id; });
     yield npmpublish.publishTag(options);
+};
+
+function* prepareRepos(repoNames) {
+    // Clone and update required repos
+    apputil.print('Cloning and updating required repositories...');
+    var reposToClone = flagutil.computeReposFromFlag(['tools'].concat(repoNames));
+    yield repoclone.cloneRepos(reposToClone, /*silent=*/true);
+    yield repoupdate.updateRepos(reposToClone, /*silent=*/true);
+
+    // Remove local changes and sync up with remote master
+    apputil.print('Resetting repositories to "master" branches...');
+    var reposToUpdate = flagutil.computeReposFromFlag(repoNames);
+    yield repoutil.forEachRepo(reposToUpdate, function*() {
+        yield gitutil.gitClean();
+        yield gitutil.resetFromOrigin();
+    });
 }
 
-function *runTests(cli, lib, ignoreTestFailures) {
-    yield repoutil.forEachRepo([cli, lib], function *(repo) {
+/**
+ * Updates provided dependencies object with versions, supplied in packageVersions object
+ * @param {Object<String, String>} packageDependencies A map of current package's dependencies to versions
+ * @param {Object<String, String>} packageVersions Map of package's id's to nightly versions
+ * @returns {Object<String, String>} A mapped object
+ */
+function mapDependenciesVersions(packageDependencies, packageVersions) {
+    return Object.keys(packageDependencies)
+    .reduce(function (result, dependency) {
+        var dep = repoutil.getRepoById(dependency);
+        // If this is a cordova-* dependency, and we're going to build nightly for it
+        if (dependency.match(/cordova\-.*/) && dep && packageVersions[dep.id]) {
+            // Update its version in package's dependencies to nightly version
+            apputil.print('Updating ' + dependency + ' dependency version to ' + packageVersions[dep.id]);
+            result[dependency] = packageVersions[dep.id];
+        }
+
+        return result;
+    }, packageDependencies);
+}
+
+function *runTests(repos, ignoreTestFailures) {
+    yield repoutil.forEachRepo(repos, function *(repo) {
         try {
             yield executil.execHelper(executil.ARGS('npm test'), false, ignoreTestFailures);
         } catch (e) {
@@ -135,4 +171,36 @@ function *runTests(cli, lib, ignoreTestFailures) {
             apputil.print('Skipping failing tests due to "ignore-test-failures flag"');
         }
     });
+}
+
+/**
+ * Generates suffix for appending to nightly package version
+ *   based on current date and SHA string.
+ * @param SHA {String} String to use to generate nightly version
+ * @returns {String} A newly generated nightly suffix
+ */
+function getNightlySuffix (SHA) {
+    var currentDate = new Date();
+    var nightlySuffix = '-nightly.' + currentDate.getFullYear() + '.' +
+        (currentDate.getMonth() + 1) + '.' + currentDate.getDate() +
+        '+' + SHA;
+
+    return nightlySuffix;
+}
+
+/**
+ * Generates map of repo.id -> nightly version based on current
+ *   date and SHA of current revision of repository
+ * @param {Object[]} repos An array of cordova repos
+ * @returns {Object} Mapped object
+ */
+function* retrieveVersions(repos) {
+    var SHAJSON = yield retrieveSha(repos);
+
+    return Object.keys(SHAJSON).reduce(function (result, repoId) {
+        var repoPath = repoutil.getRepoDir(repoutil.getRepoById(repoId));
+        var oldVersion = require(path.join(repoPath, 'package.json')).version;
+        result[repoId] = versionutil.removeDev(oldVersion) + getNightlySuffix(SHAJSON[repoId]);
+        return result;
+    }, {});
 }

--- a/src/nightly.js
+++ b/src/nightly.js
@@ -76,7 +76,7 @@ module.exports = function*(argv) {
         yield versionutil.updateRepoVersion(repo, VERSIONS[repo.id], { commitChanges: false });
 
         var packageJSONPath = path.join(process.cwd(), 'package.json');
-        var packageJSON = require(packageJSONPath);
+        var packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));
 
         // If there is a dependencies listed, iterate through and update cordova-* dependencies
         packageJSON.dependencies = mapDependenciesVersions(packageJSON.dependencies, VERSIONS);

--- a/src/nightly.js
+++ b/src/nightly.js
@@ -81,7 +81,7 @@ module.exports = function*(argv) {
         // If there is a dependencies listed, iterate through and update cordova-* dependencies
         packageJSON.dependencies = mapDependenciesVersions(packageJSON.dependencies, VERSIONS);
 
-        fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 4), 'utf8', function(err) {
+        fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2) + '\n', 'utf8', function(err) {
             if (err) return console.log (err);
         });
     });

--- a/src/nightly.js
+++ b/src/nightly.js
@@ -69,14 +69,14 @@ module.exports = function*(argv) {
     /** @type {Object} A map of repo.id and a short SHA for every repo to build */
     var VERSIONS = yield retrieveVersions(reposToBuild);
 
-    //update package.json version for cli + lib, update lib reference for cli
+    // Update version in package.json and other respective files for every repo
+    // and update dependencies to use nightly versions of packages to be released
     yield repoutil.forEachRepo(reposToBuild, function*(repo) {
+        apputil.print('Updating ' + repo.id + ' version to ' + VERSIONS[repo.id]);
+        yield versionutil.updateRepoVersion(repo, VERSIONS[repo.id], { commitChanges: false });
+
         var packageJSONPath = path.join(process.cwd(), 'package.json');
         var packageJSON = require(packageJSONPath);
-
-        // Update package version
-        apputil.print('Updating ' + repo.id + ' version to ' + VERSIONS[repo.id]);
-        packageJSON.version = VERSIONS[repo.id];
 
         // If there is a dependencies listed, iterate through and update cordova-* dependencies
         packageJSON.dependencies = mapDependenciesVersions(packageJSON.dependencies, VERSIONS);

--- a/src/npm-publish.js
+++ b/src/npm-publish.js
@@ -74,14 +74,8 @@ function *publishTag(options) {
 
 module.exports.publishTag = publishTag;
 
-//TODO: Does npm tag cordova-js*.tgz latest
-exports.setLatest = function*(argv) {
-
-
-}
-
 //Gets last nightly tag and unpublishes it
-function *unpublish(options) {
+function *unpublishNightly(options) {
     var opt = flagutil.registerHelpFlag(optimist);
 
     if(options) {
@@ -92,12 +86,9 @@ function *unpublish(options) {
             .options('r', {
                 default:options.r
             })
-            .options('version', {
-                default:options.version
-            })
     }
 
-    argv = opt
+    var argv = opt
         .usage("Unpublishes the nightly version for the cli & lib from npm \n" +
                 "Usage: $0 npm-unpublish-nightly")
         .options("pretend", {
@@ -105,11 +96,7 @@ function *unpublish(options) {
             type: "boolean"
         })
         .options('r', {
-            desc: "Which repo(s) to publish",
-            demand: true
-        })
-        .options('version', {
-            desc: "Which version to unpublish",
+            desc: "Which repo(s) to unpublish",
             demand: true
         })
         .argv;
@@ -123,8 +110,12 @@ function *unpublish(options) {
 
     yield repoutil.forEachRepo(repos, function*(repo) {
         var packageId = repo.packageName || repo.repoName;
-        yield executil.execOrPretend(executil.ARGS('npm unpublish '+ packageId + '@' + argv.version), argv.pretend);
+        var oldNightlyVersion = yield executil.execHelper(executil.ARGS('npm view ' + packageId + ' dist-tags.nightly'));
+
+        if (oldNightlyVersion && oldNightlyVersion !== 'undefined') {
+            yield executil.execOrPretend(executil.ARGS('npm unpublish '+ packageId + '@' + oldNightlyVersion), argv.pretend);
+        }
     });
 }
 
-module.exports.unpublish = unpublish;
+module.exports.unpublishNightly = unpublishNightly;

--- a/src/repoutil.js
+++ b/src/repoutil.js
@@ -443,7 +443,7 @@ function getRepoById(id, opt_repos) {
     // Strip cordova- prefix if it exists.
     var repos = opt_repos || allRepos;
     for (var i = 0; i < repos.length; ++i) {
-        if (repos[i].id == id || repos[i].repoName == id) {
+        if (repos[i].id == id || repos[i].packageName == id || repos[i].repoName == id) {
             return repos[i];
         }
     }

--- a/src/repoutil.js
+++ b/src/repoutil.js
@@ -439,6 +439,15 @@ repoGroups.__defineGetter__('auto', function() {
 
 exports.repoGroups = repoGroups;
 
+function isInRepoGroup(repoToCheck, groupName) {
+    var repos = repoGroups[groupName];
+    if (!repos) return false;
+    return repos.some(function (repo) {
+        return repo.id === repoToCheck.id;
+    });
+}
+exports.isInRepoGroup = isInRepoGroup;
+
 function getRepoById(id, opt_repos) {
     // Strip cordova- prefix if it exists.
     var repos = opt_repos || allRepos;

--- a/src/versionutil.js
+++ b/src/versionutil.js
@@ -56,7 +56,7 @@ function *updatePlatformsConfig(newValues) {
         }
     });
 
-    fs.writeFileSync(platformsConfig, JSON.stringify(platformsJS, null, 4), 'utf8', function(err) {
+    fs.writeFileSync(platformsConfig, JSON.stringify(platformsJS, null, 4) + '\n', 'utf8', function(err) {
         if (err) return console.log (err);
     });
 }
@@ -111,7 +111,8 @@ exports.updateRepoVersion = function *updateRepoVersion(repo, version, opts) {
             if (err) throw err;
             var packageJSON = JSON.parse(data);
             packageJSON.version = version;
-            fs.writeFileSync(packageFilePaths[0], JSON.stringify(packageJSON, null, "    "));
+            // use 2 spaces indent similar to npm
+            fs.writeFileSync(packageFilePaths[0], JSON.stringify(packageJSON, null, 2) + '\n');
         });
         if (!(yield gitutil.pendingChangesExist())) {
             apputil.print('package.json file was already up-to-date.');


### PR DESCRIPTION
This PR adds the following features to `coho nightly` command:
- it now accepts `--repo` flag to specify repos to build nightlies for (instead of using predefined repos) . If `--repo` is not specified, cordova-cli and cordova-lib will be built.
- it now updates dependencies for every package to point to newly released nightly versions
- it handles the situation when the repo is not yet published under `nightly` tag gracefully
