### PR TITLE
CB-7904 Update version format to include SHA and use UTC date

### DIFF
--- a/src/nightly.js
+++ b/src/nightly.js
@@ -73,15 +73,15 @@ module.exports = function*(argv) {
     var SHAJSON = yield retrieveSha(repos);
 
     var currentDate = new Date();
-    var nightlyVersion = '-nightly.' + currentDate.getFullYear() + '.' +
-        (currentDate.getMonth() + 1) + '.' + currentDate.getDate();
+    var nightlyVersion = '-nightly.' + currentDate.getUTCFullYear() + '.' +
+        (currentDate.getUTCMonth() + 1) + '.' + currentDate.getUTCDate();
     var cordovaLibVersion;
     //update package.json version for cli + lib, update lib reference for cli
     yield repoutil.forEachRepo([cordovaLib, cli], function*(repo) {
         var dir = process.cwd();
         var packageJSON = require(dir+'/package.json');
         packageJSON.version = versionutil.removeDev(packageJSON.version) + nightlyVersion +
-            '+' + SHAJSON[repo.id];
+            '.' + SHAJSON[repo.id];
 
         if(repo.id === 'lib'){
             cordovaLibVersion = packageJSON.version;


### PR DESCRIPTION
Updating as per [discussion](https://github.com/cordova/cordova-discuss/pull/47#discussion_r63589276).
Not including `attempt` as this should be a rare case and it only affects `semver.sort` (i.e. `<package_id>@<next_version>-nightly.<build_date>.<commit_SHA>` > `<package_id>@<next_version>-nightly.<build_date>.<attempt>.<commit_SHA>`), which we are not using now.
In case a nightly will be needed to re-published multiple times a date it should be possible to unpublish the old one (in 24 hours period) - else it will be another date so an `attempt` suffix will not be needed.