### PR TITLE
CB-11280 Pin nightly platforms versions

### DIFF
--- a/src/nightly.js
+++ b/src/nightly.js
@@ -86,6 +86,12 @@ module.exports = function*(argv) {
         });
     });
 
+    // Pin nightly versions of platforms
+    if (reposToBuild.some(function (repo) { return repo.id === 'lib'; })) {
+        apputil.print('Updating platforms pinned versions...');
+        versionutil.updatePlatformsConfig(VERSIONS);
+    }
+
     //npm link repos that should be linked
     yield npmlink();
 

--- a/src/versionutil.js
+++ b/src/versionutil.js
@@ -36,23 +36,16 @@ exports.removeDev = removeDev;
 //Needs to be passed a object which includes repo.id as key
 //and the new version as value
 //ex {android:4.0.0}
-function *updatePlatformsConfig(newValues) {
-
-    var platformsConfig = path.join(repoutil.getRepoDir('cordova-lib'),
-        'src/cordova/platformsConfig.json');
-    console.log(platformsConfig);
+function updatePlatformsConfig(newValues) {
+    var platformsConfig = path.join(repoutil.getRepoDir(repoutil.getRepoById('lib')), 'src/platforms/platformsConfig.json');
     var platformsJS = require(platformsConfig);
 
-    var repos = flagutil.computeReposFromFlag('active-platform');
-
-    yield repoutil.forEachRepo(repos, function*(repo) {
-        if(repo.id === 'windows') {
-            platformsJS[repo.id].version = newValues[repo.id];
-            platformsJS['windows8'].version = newValues[repo.id];
-        } else if(repo.id === 'blackberry') {
-            platformsJS['blackberry10'].version = newValues[repo.id];
-        } else {
-            platformsJS[repo.id].version = newValues[repo.id];
+    flagutil.computeReposFromFlag('active-platform')
+    .forEach(function(repo) {
+        if (newValues[repo.id]) {
+            // For blackberry platformsConfig.json uses 'blackberry10' key
+            var correctRepoId = (repo.id === 'blackberry') ? "blackberry10" : repo.id;
+            platformsJS[correctRepoId].version = newValues[repo.id];
         }
     });
 
@@ -92,7 +85,6 @@ exports.updateRepoVersion = function *updateRepoVersion(repo, version, opts) {
             shelljs.sed('-i', /VERSION.*=.*;/, 'VERSION = "' + version + '";', path.join('bin', 'templates', 'project','cordova', 'version'));
         } else if (repo.id == 'windows') {
             if(fs.existsSync(path.join('template', 'cordova', 'version'))) {
-                console.log('version exists');
                 shelljs.sed('-i', /VERSION.*=.*;/, 'VERSION = "' + version + '";', path.join('template', 'cordova', 'version'));
             }
         }

--- a/src/versionutil.js
+++ b/src/versionutil.js
@@ -37,7 +37,9 @@ exports.removeDev = removeDev;
 //and the new version as value
 //ex {android:4.0.0}
 function updatePlatformsConfig(newValues) {
-    var platformsConfig = path.join(repoutil.getRepoDir(repoutil.getRepoById('lib')), 'src/platforms/platformsConfig.json');
+
+    var platformsConfig = path.join(repoutil.getRepoDir(repoutil.getRepoById('lib')),
+        'src/platforms/platformsConfig.json');
     var platformsJS = require(platformsConfig);
 
     flagutil.computeReposFromFlag('active-platform')


### PR DESCRIPTION
This PR updates `coho nightly` command to pin platforms to their nightly versions in `cordova-lib/platfomsConfig.json` in order to use these nightly versions by default in `cordova platform add` command

At also ensures that platforms `cordova-*` dependencies is up to date and will be included into resultant package (for now this actual for `cordova-common` dependency only)