### PR TITLE
CB-12758 - Add cordova-fetch, cordova-common and cordova-create to the nightly build

### DIFF
--- a/src/nightly.js
+++ b/src/nightly.js
@@ -32,7 +32,7 @@ var repoclone = require('./repo-clone');
 
 module.exports = function*(argv) {
     /** Specifies the default repos to build nightlies for */
-    var DEFAULT_NIGHTLY_REPOS = ['cli', 'lib'];
+    var DEFAULT_NIGHTLY_REPOS = ['cli', 'lib', 'fetch', 'common'];
 
     var opt = flagutil.registerHelpFlag(optimist);
     opt = flagutil.registerRepoFlag(opt);

--- a/src/nightly.js
+++ b/src/nightly.js
@@ -32,7 +32,7 @@ var repoclone = require('./repo-clone');
 
 module.exports = function*(argv) {
     /** Specifies the default repos to build nightlies for */
-    var DEFAULT_NIGHTLY_REPOS = ['cli', 'lib', 'fetch', 'common'];
+    var DEFAULT_NIGHTLY_REPOS = ['cli', 'lib', 'fetch', 'common', 'create'];
 
     var opt = flagutil.registerHelpFlag(optimist);
     opt = flagutil.registerRepoFlag(opt);

--- a/src/npm-publish.js
+++ b/src/npm-publish.js
@@ -64,7 +64,7 @@ function *publishTag(options) {
         process.exit(1);
     }
 
-    var repos = flagutil.computeReposFromFlag(argv.r);
+    var repos = flagutil.computeReposFromFlag(argv.r, { includeModules: true });
 
     //npm publish --tag argv.tag
     yield repoutil.forEachRepo(repos, function*(repo) {


### PR DESCRIPTION
### Platforms affected

Tools only, nightlies.

### What does this PR do?

Adds cordova-common and cordova-fetch to the nightlies.

### What testing has been done on this change?

`--pretend` flag

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
