### PR TITLE
Fix link

### DIFF
--- a/docs/committer-workflow.md
+++ b/docs/committer-workflow.md
@@ -97,7 +97,7 @@ When possible, try to phrase things in the form of a proposal. If no one objects
    * Platforms: Native unit tests (i.e., `cordova-android/test`, `cordova-ios/CordovaLibTests`)
    * Cordova JS: Run `grunt test`
  * If there is no existing test that exercises your code, consider adding one
- * If you are writing documentation (i.e., cordova-docs), be aware of the [style guidelines](https://github.com/apache/cordova-docs/blob/master/STYLESHEET.md|style guidelines).
+ * If you are writing documentation (i.e., cordova-docs), be aware of the [style guidelines](https://github.com/apache/cordova-docs/blob/master/STYLESHEET.md).
 
 ### Step 6: Ask for a code review (_optional_)
  * Do this if you want a second pair of eyes to look at your code before it goes in.


### PR DESCRIPTION
Trivial fix. Was reading using GitHub web interface and noticed the broken link, due to the syntax error.

Cheers
Bruno

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

None

### What does this PR do?

Fixes the README Markdown syntax.

### What testing has been done on this change?

Preview in GitHub UI.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

None of the above, sorry.
