### PR TITLE
Remove cordova-plugin-compat

### DIFF
--- a/src/repoutil.js
+++ b/src/repoutil.js
@@ -181,11 +181,6 @@ var pluginRepos = [
         repoName: 'cordova-plugin-contacts',
         jiraComponentName: 'cordova-plugin-contacts'
     }, {
-        title: 'Plugin - Compat',
-        id: 'plugin-compat',
-        repoName: 'cordova-plugin-compat',
-        jiraComponentName: 'cordova-plugin-compat'
-    }, {
         title: 'Plugin - Device Motion',
         id: 'plugin-device-motion',
         repoName: 'cordova-plugin-device-motion',


### PR DESCRIPTION
### Platforms affected

Android

### What does this PR do?

Removes cordova-plugin-compat from cordova-coho

### What testing has been done on this change?

Absolutely none. Sue me, I'm honest.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
