### PR TITLE
CB-13119: Added inactive flag for file transfer plugin

### DIFF
--- a/src/repoutil.js
+++ b/src/repoutil.js
@@ -215,7 +215,8 @@ var pluginRepos = [
         title: 'Plugin - File Transfer',
         id: 'plugin-file-transfer',
         repoName: 'cordova-plugin-file-transfer',
-        jiraComponentName: 'cordova-plugin-file-transfer'
+        jiraComponentName: 'cordova-plugin-file-transfer',
+        inactive: true
     }, {
         title: 'Plugin - File',
         id: 'plugin-file',


### PR DESCRIPTION
This PR updates the reference for cordova-plugin-file-transfer as inactive.


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
