### PR TITLE
CB-13065 : Updated cordova contacts plugin reference as inactive

### DIFF
--- a/src/repoutil.js
+++ b/src/repoutil.js
@@ -182,7 +182,8 @@ var pluginRepos = [
         title: 'Plugin - Contacts',
         id: 'plugin-contacts',
         repoName: 'cordova-plugin-contacts',
-        jiraComponentName: 'cordova-plugin-contacts'
+        jiraComponentName: 'cordova-plugin-contacts',
+        inactive: true
     }, {
         title: 'Plugin - Compat',
         id: 'plugin-compat',


### PR DESCRIPTION
Updated reference of cordova-plugin-contacts as inactive in cordova coho




### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
