### PR TITLE
WORKAROUND SOLUTION for local grunt issue in cordova-js

### DIFF
--- a/src/platform-release.js
+++ b/src/platform-release.js
@@ -142,7 +142,9 @@ function * updateJsSnapshot (repo, version, commit) {
                     // git fetch and update master for cordovajs
                     yield repoupdate.updateRepos([cordovaJsRepo], ['master'], false);
                     yield gitutil.gitCheckout('master');
+                    yield executil.execHelper(executil.ARGS('npm install'), false, true); // WORKAROUND PART 1 for local grunt issue in cordova-js
                     yield executil.execHelper(executil.ARGS('grunt compile:' + repo.id + ' --platformVersion=' + version), false, true);
+                    shelljs.rm('-fr', 'node_modules'); // WORKAROUND PART 2 for local grunt issue in cordova-js
                     hasBuiltJs = version;
                 });
             });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?


**Resolves the following issue:**

If I would try `coho prepare-platform-release-branch` or `coho copy-js` it stops with an error like this:

```sh
cordova-js/ ==================== Executing: grunt compile:android --platformVersion=7.1.1-dev
grunt-cli: The grunt command line interface (v1.2.0)

Fatal error: Unable to find local grunt.
```

If I would try `npm install` in `cordova-js` it does not resolve the issue. `coho` seems to clean `node_modules` before attempting `grunt compile:android`.

Ugly workaround was to commit node_modules in my local (personal) master branch of cordova-js (NOT in the apache repo) before running `coho prepare-platform-release-branch` or `coho copy-js`.

The update proposed here is a workaround solution that automatically does `npm install` in `cordova-js` to solve the grunt issue described here.

**Moving forward:**

I would like to see at least one other member try this change before integrating into master. I have not tried it with more than one platform at a time (not sure if I would favor updating more than one platform at a time anyway).

I think a much nicer solution would be for us to move on to a more modern solution such as WebPack, microbundle, or maybe even Gulp instead of Grunt.

### What testing has been done on this change?

Both `./cordova-coho/coho copy-js -r android` and `./cordova-coho/coho prepare-platform-release-branch --version 8.0.0-dev -r android` work as expected for me.

(I generally use a local clone of the `cordova-coho` repo for `coho` tasks.)

### Checklist

- ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~