### PR TITLE
CB-14185: (tooling) Skip md5 use for create-archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ apache-rat-0.12
 node_modules
 .idea
 **/*.swp
+
+.DS_Store


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all

### What does this PR do?
removes md5 creation, md5 is too broken

### What testing has been done on this change?
npm test
created + verified an archive

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
