### PR TITLE
Clarify platform release buy-in and JIRA issue timing

### DIFF
--- a/docs/platforms-release-process.md
+++ b/docs/platforms-release-process.md
@@ -97,7 +97,7 @@ You should have your platform repository checked out in a folder where you also 
 
 ### Request buy-in
 
-Email the dev mailing-list at dev@cordova.apache.org and see if anyone has reason to postpone the release.
+Email the dev mailing-list at <dev@cordova.apache.org> and see if anyone has reason to postpone the release.
 
 E.g.:
 

--- a/docs/platforms-release-process.md
+++ b/docs/platforms-release-process.md
@@ -28,13 +28,13 @@ It describes the following steps:
 - [General instructions](#general-instructions)
   * [Repository setup](#repository-setup)
 - [Before you start](#before-you-start)
-  * [Get Buy-in](#get-buy-in)
-  * [Create JIRA issue](#create-jira-issue)
+  * [Request buy-in](#request-buy-in)
 - [Before Release](#before-release)
   * [Check dependencies](#check-dependencies)
   * [Update and Pin Dependencies](#update-and-pin-dependencies)
   * [npm audit check](#npm-audit-check)
   * [License Check](#license-check)
+  * [Create JIRA issue](#create-jira-issue)
 - [Prepare Release](#prepare-release)
   * [Set release version in `package.json`](#set-release-version-in-packagejson)
     - [Remove the `-dev` suffix from version](#remove-the--dev-suffix-from-version)
@@ -95,7 +95,7 @@ You should have your platform repository checked out in a folder where you also 
 
 ## Before you start
 
-### Get Buy-in
+### Request buy-in
 
 Email the dev mailing-list at dev@cordova.apache.org and see if anyone has reason to postpone the release.
 
@@ -110,19 +110,7 @@ E.g.:
 
 Double check you replace "Android" in the subject and mail body - there is no undo for emails.
 
-### Create JIRA issue
-
- * Create a JIRA issue to track the status of the release.
-   - Make it of type "Task"
-   - Title should be "Cordova-Android Platform Release _August 21, 2014_"
-   - Description should be: "Following steps at https://github.com/apache/cordova-coho/blob/master/docs/platforms-release-process.md"
- * Comments should be added to this bug after each top-level step below is taken
- * Set a variable in your terminal for use later on
-
-
-```
-JIRA="CB-????" # Set this to the release bug.
-```
+Note that it would be possible to continue with some of the [Before Release](#before-release) items while waiting for a possible response.
 
 ## Before Release
 
@@ -168,6 +156,22 @@ Ensure license headers are present everywhere. For reference, see this [backgrou
 Ensure all dependencies and subdependencies have Apache-compatible licenses.
 
     coho check-license -r android
+
+### Create JIRA issue
+
+After waiting for any possible objections from [Request Buy-in](#request-buy-in):
+
+ * Create a JIRA issue to track the status of the release.
+   - Make it of type "Task"
+   - Title should be "Cordova-Android Platform Release _August 21, 2014_"
+   - Description should be: "Following steps at https://github.com/apache/cordova-coho/blob/master/docs/platforms-release-process.md"
+ * Comments should be added to this bug after each top-level step below is taken
+ * Set a variable in your terminal for use later on
+
+
+```
+JIRA="CB-????" # Set this to the release bug.
+```
 
 ## Prepare Release
 

--- a/docs/platforms-release-process.md
+++ b/docs/platforms-release-process.md
@@ -176,7 +176,7 @@ Ensure all dependencies and subdependencies have Apache-compatible licenses.
 
 ### Create JIRA issue
 
-After waiting for any possible objections from [Request Buy-in](#request-buy-in):
+After waiting for any possible objections from the email sent according to the [Request buy-in](#request-buy-in) section above:
 
  * Create a JIRA issue to track the status of the release.
    - Make it of type "Task"


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

- Preserve and update platform release "Request buy-in" section with timing near the beginning, preserving blame with help from `git merge`
- Mark email address for proper `cmark` (GitHub Markdown) processing
- Clarify when to raise the JIRA issue for the platform release (after waiting for any possible objections from "Request buy-in" section)

Raised in response to <https://github.com/apache/cordova-coho/pull/181#discussion_r205843535>

### What testing has been done on this change?

- Checked for proper rendering and working cross-references in <https://github.com/brodybits/cordova-coho/blob/clarify-platform-release-buy-in-and-jira-timing/docs/platforms-release-process.md>
- Checked that original blame for "Request buy-in" section shows the original commits and not my own (<https://github.com/brodybits/cordova-coho/blame/clarify-platform-release-buy-in-and-jira-timing/docs/platforms-release-process.md>)

### Checklist

- ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~