### PR TITLE
Improve patch and dev version support

### DIFF
--- a/docs/platforms-release-process.md
+++ b/docs/platforms-release-process.md
@@ -260,13 +260,19 @@ Create and prepare your release branch by using `coho prepare-platform-release-b
 3. Propagates version number from `--version` argument (or from `package.json` if there is no `--version` argument) to all other files (`VERSION` and similar [e.g. `build.gradle` for Android]) on the release branch `5.0.x`
 4. Prepares `master` for future development already: It gives version (`package.json`, `VERSION` and similar) a minor bump and adds `-dev` (=> `5.1.0-dev`) again
 
-Run the following command (make sure to replace the version below with what is listed inside `package.json`).
+Run the following command (make sure to replace the version below with what is listed inside `package.json`) in case of release from the `master`:
 
-    coho prepare-platform-release-branch --version 5.0.0 -r android
+    coho prepare-platform-release-branch --version 7.2.0 -r android
+
+or in case of release from another release branch:
+
+    coho prepare-platform-release-branch --version 7.1.1 -r android -b 7.1.x
 
 Then ensure commits look okay on both branches
 
-    coho repo-status -r android -b master -b 5.0.x
+    coho repo-status -r android -b master -b 7.1.x
+
+or use git tool to verify manually.
 
 ## Testing
 
@@ -357,25 +363,31 @@ Create a JIRA issue for it, and mark it as a blocker.
 
 All good? Have another look at the changes:
 
-    coho repo-status -r android -b master -b 5.0.x
+    coho repo-status -r android -b master -b 7.1.x
 
 If changes look right:
 
     coho repo-push -r android -b master -b 5.0.x
 
-This pushes the commits in both `master` and `5.0.x` (the release branch) to the remote.
+This pushes the commits in both `master` and `7.1.x` (the release branch) to the remote.
 
 ### Tag and push tag
 
 Before you tag, run this command:
 
-    coho tag-platform-release --version 5.0.0 -r android --pretend
+    coho tag-platform-release --version 7.1.0 -r android --pretend
     
 Seems okay? Then execute it by running:
 
-    coho tag-platform-release --version 5.0.0 -r android
+    coho tag-platform-release --version 7.1.0 -r android
 
-This command also tags `cordova-js` with `android-5.0.0` and pushes it.
+This command also tags `cordova-js` with `android-7.1.0` and pushes it.
+
+To tag without automatic push:
+
+    coho tag-platform-release --version 7.1.0 -r android --tag-only
+
+and then manually push the new tags.
 
 ## Publish Release Candidate to `dist/dev`
 

--- a/src/gitutil.js
+++ b/src/gitutil.js
@@ -137,6 +137,10 @@ exports.pendingChangesExist = function * () {
 exports.gitCheckout = function * (branchName) {
     var curBranch = yield gitutil.retrieveCurrentBranchName(true);
     if (curBranch !== branchName) {
+        // EXTRA WORKAROUND SOLUTION for package.json,
+        // as needed for cordova-osx & Windows
+        // FUTURE TBD better solution for package.json?
+        yield executil.execHelper(executil.ARGS('git checkout -- package.json'));
         return yield executil.execHelper(executil.ARGS('git checkout -q ', branchName));
     }
 };

--- a/src/platform-release.js
+++ b/src/platform-release.js
@@ -197,7 +197,7 @@ exports.prepareReleaseBranchCommand = function * () {
                'Command can also be used to update the JS snapshot after release \n' +
                'branches have been created.\n' +
                '\n' +
-               'Usage: $0 prepare-release-branch -r platform [--version=3.6.0]')
+               'Usage: $0 prepare-platform-release-branch -r platform [--version=3.6.0]')
     );
 
     var repos = flagutil.computeReposFromFlag(argv.r);

--- a/src/platform-release.js
+++ b/src/platform-release.js
@@ -214,14 +214,7 @@ exports.prepareReleaseBranchCommand = function * () {
         yield gitutil.stashAndPop(repo, function * () {
             // git fetch + update master
             yield repoupdate.updateRepos([repo], ['master'], false);
-            if (platform === 'ios') {
-                // Updates version in CDVAvailability.h file
-                yield updateCDVAvailabilityFile(version);
-                // Git commit changes
-                if (yield gitutil.pendingChangesExist()) {
-                    yield executil.execHelper(executil.ARGS('git commit -am', 'Added ' + version + ' to CDVAvailability.h (via coho).'));
-                }
-            }
+
             // Either create or pull down the branch.
             if (yield gitutil.remoteBranchExists(repo, branchName)) {
                 print('Remote branch already exists for repo: ' + repo.repoName);
@@ -236,8 +229,18 @@ exports.prepareReleaseBranchCommand = function * () {
             }
 
             yield updateJsSnapshot(repo, version, true);
+
             print(repo.repoName + ': Setting VERSION to "' + version + '" on branch "' + branchName + '".');
             yield versionutil.updateRepoVersion(repo, version);
+
+            if (platform === 'ios') {
+                // Updates version in CDVAvailability.h file
+                yield updateCDVAvailabilityFile(version);
+                // Git commit changes
+                if (yield gitutil.pendingChangesExist()) {
+                    yield executil.execHelper(executil.ARGS('git commit -am', 'Added ' + version + ' to CDVAvailability.h (via coho).'));
+                }
+            }
 
             yield gitutil.gitCheckout('master');
             var devVersion = createPlatformDevVersion(version);

--- a/src/platform-release.js
+++ b/src/platform-release.js
@@ -143,6 +143,10 @@ function * updateJsSnapshot (repo, version, commit, branch) {
                     if (branch === 'master') {
                         yield repoupdate.updateRepos([cordovaJsRepo], [branch], false);
                     }
+                    // EXTRA WORKAROUND SOLUTION for package.json,
+                    // as needed for cordova-osx & Windows
+                    // FUTURE TBD better solution for package.json?
+                    yield executil.execHelper(executil.ARGS('git checkout -- package.json'));
                     yield executil.execHelper(executil.ARGS('git checkout -q ' + branch));
                     yield gitutil.gitCheckout(branch);
                     yield executil.execHelper(executil.ARGS('npm install'), false, true); // WORKAROUND PART 1 for local grunt issue in cordova-js

--- a/src/platform-release.js
+++ b/src/platform-release.js
@@ -171,7 +171,7 @@ function * updateJsSnapshot (repo, version, commit, branch, commitPrefixOrUndefi
         if (commit === true) {
             if (yield gitutil.pendingChangesExist()) {
                 var pre = !!commitPrefixOrUndefined ? commitPrefixOrUndefined : '';
-                yield executil.execHelper(executil.ARGS('git commit -am', pre + 'Update JS snapshot to version ' + version + ' (via coho)'));
+                yield executil.execHelper(executil.ARGS('git commit -am', pre + 'Update JS to version ' + version + ' (via coho)'));
             }
         }
     } else if (repoutil.repoGroups.all.indexOf(repo) !== -1) {

--- a/src/platform-release.js
+++ b/src/platform-release.js
@@ -130,7 +130,7 @@ function * updateCDVAvailabilityFile (version) {
     fs.writeFileSync(iosFile, iosFileContents.join('\n'));
 }
 
-function * updateJsSnapshot (repo, version, commit) {
+function * updateJsSnapshot (repo, version, commit, branch) {
     function * ensureJsIsBuilt () {
         var cordovaJsRepo = repoutil.getRepoById('js');
         if (repo.id === 'blackberry') {
@@ -139,9 +139,12 @@ function * updateJsSnapshot (repo, version, commit) {
         if (hasBuiltJs !== version) {
             yield repoutil.forEachRepo([cordovaJsRepo], function * () {
                 yield gitutil.stashAndPop(cordovaJsRepo, function * () {
-                    // git fetch and update master for cordovajs
-                    yield repoupdate.updateRepos([cordovaJsRepo], ['master'], false);
-                    yield gitutil.gitCheckout('master');
+                    // git fetch and update master (or fetch other branch) for cordova-js
+                    if (branch === 'master') {
+                        yield repoupdate.updateRepos([cordovaJsRepo], [branch], false);
+                    }
+                    yield executil.execHelper(executil.ARGS('git checkout -q ' + branch));
+                    yield gitutil.gitCheckout(branch);
                     yield executil.execHelper(executil.ARGS('npm install'), false, true); // WORKAROUND PART 1 for local grunt issue in cordova-js
                     yield executil.execHelper(executil.ARGS('grunt compile:' + repo.id + ' --platformVersion=' + version), false, true);
                     shelljs.rm('-fr', 'node_modules'); // WORKAROUND PART 2 for local grunt issue in cordova-js
@@ -177,13 +180,16 @@ exports.createAndCopyCordovaJSCommand = function * () {
                '    1. Generates a new cordova.js.\n' +
                '    2. Replaces platform\'s cordova.js file.\n' +
                '\n' +
-               'Usage: $0 copy-js -r platform')
+               'Usage: $0 copy-js -r platform [--js <cordova-js branch or tag name>]')
     );
 
     var repos = flagutil.computeReposFromFlag(argv.r);
+
+    var jsBranchName = argv.js ? argv.js : 'master';
+
     yield repoutil.forEachRepo(repos, function * (repo) {
         var version = yield handleVersion(repo, argv.version, false);
-        yield updateJsSnapshot(repo, version, false);
+        yield updateJsSnapshot(repo, version, false, jsBranchName);
     });
 };
 
@@ -199,11 +205,17 @@ exports.prepareReleaseBranchCommand = function * () {
                'Command can also be used to update the JS snapshot after release \n' +
                'branches have been created.\n' +
                '\n' +
-               'Usage: $0 prepare-platform-release-branch -r platform [--version=3.6.0]')
+               'Usage: $0 prepare-platform-release-branch -r platform [--version=3.6.0] [-b <platform branch name>] [--js <cordova-js branch or tag name>]')
     );
 
     var repos = flagutil.computeReposFromFlag(argv.r);
+
+    // XXX TBD ???:
     var branchName = null;
+
+    var isOtherRepoBranch = !!argv.b;
+    var repoBranchName = isOtherRepoBranch ? argv.b : 'master';
+    var jsBranchName = argv.js ? argv.js : 'master';
 
     // First - perform precondition checks.
     yield repoupdate.updateRepos(repos, [], true);
@@ -211,34 +223,32 @@ exports.prepareReleaseBranchCommand = function * () {
     yield repoutil.forEachRepo(repos, function * (repo) {
         var platform = repo.id;
         var version = yield handleVersion(repo, argv.version, true);
-        var branchName = versionutil.getReleaseBranchNameFromVersion(version);
+        var releaseBranchName = isOtherRepoBranch ? repoBranchName :
+                versionutil.getReleaseBranchNameFromVersion(version);
 
         yield gitutil.stashAndPop(repo, function * () {
             // git fetch + update master
-            yield repoupdate.updateRepos([repo], ['master'], false);
+            yield repoupdate.updateRepos([repo], [repoBranchName], false);
 
             // Either create or pull down the branch.
-            if (yield gitutil.remoteBranchExists(repo, branchName)) {
+            if (yield gitutil.remoteBranchExists(repo, releaseBranchName)) {
                 print('Remote branch already exists for repo: ' + repo.repoName);
                 // Check out and rebase.
-                yield repoupdate.updateRepos([repo], [branchName], true);
-                yield gitutil.gitCheckout(branchName);
-            } else if (yield gitutil.localBranchExists(branchName)) {
-                yield executil.execHelper(executil.ARGS('git checkout ' + branchName));
+                yield repoupdate.updateRepos([repo], [releaseBranchName], true);
+                yield gitutil.gitCheckout(releaseBranchName);
+            } else if (yield gitutil.localBranchExists(releaseBranchName)) {
+                yield executil.execHelper(executil.ARGS('git checkout ' + releaseBranchName));
+            } else if (isOtherRepoBranch) {
+                yield executil.execHelper(executil.ARGS('git checkout ' + repoBranchName));
             } else {
                 yield gitutil.gitCheckout('master');
-                yield executil.execHelper(executil.ARGS('git checkout -b ' + branchName));
+                yield executil.execHelper(executil.ARGS('git checkout -b ' + releaseBranchName));
             }
 
-            print(repo.repoName + ': Update JS snapshot version for VERSION "' + version + '" on branch "' + branchName + '".');
-            yield updateJsSnapshot(repo, version, true);
+            yield updateJsSnapshot(repo, version, true, jsBranchName);
 
-            print(repo.repoName + ': Setting VERSION to "' + version + '" on branch "' + branchName + '".');
-            yield versionutil.updateRepoVersion(repo, version);
-
-            if (platform === 'ios') {
+            if (platform === 'ios' && /\d$/.test(version)) {
                 // Updates version in CDVAvailability.h file
-                print(repo.repoName + ': Update CDVAvailability.h for VERSION to "' + version + '" on branch "' + branchName + '".');
                 yield updateCDVAvailabilityFile(version);
                 // Git commit changes
                 if (yield gitutil.pendingChangesExist()) {
@@ -246,15 +256,23 @@ exports.prepareReleaseBranchCommand = function * () {
                 }
             }
 
+            print(repo.repoName + ': Setting VERSION to "' + version + '" on branch "' + releaseBranchName + '".');
+            yield versionutil.updateRepoVersion(repo, version);
+
+            // skip remaining steps for this repo if other repo branch was specified:
+            if (isOtherRepoBranch) return;
+
             yield gitutil.gitCheckout('master');
             var devVersion = createPlatformDevVersion(version);
             print(repo.repoName + ': Setting VERSION to "' + devVersion + '" on branch "master".');
             yield versionutil.updateRepoVersion(repo, devVersion);
-            yield updateJsSnapshot(repo, devVersion, true);
-            yield gitutil.gitCheckout(branchName);
+            yield updateJsSnapshot(repo, devVersion, true, jsBranchName);
+            yield gitutil.gitCheckout(releaseBranchName);
         });
     });
-    executil.reportGitPushResult(repos, ['master', branchName]);
+
+    // XXX TBD ???:
+    executil.reportGitPushResult(repos, [repoBranchName, branchName]);
 };
 
 function * tagJs (repo, version, pretend) {

--- a/src/platform-release.js
+++ b/src/platform-release.js
@@ -266,6 +266,9 @@ exports.prepareReleaseBranchCommand = function * () {
             // skip remaining steps for this repo if other repo branch was specified:
             if (isOtherRepoBranch) return;
 
+            // or skip remaining steps if not a final release version:
+            if (version.indexOf('-') !== -1) return;
+
             yield gitutil.gitCheckout('master');
             var devVersion = createPlatformDevVersion(version);
             print(repo.repoName + ': Setting VERSION to "' + devVersion + '" on branch "master".');

--- a/src/platform-release.js
+++ b/src/platform-release.js
@@ -228,6 +228,7 @@ exports.prepareReleaseBranchCommand = function * () {
                 yield executil.execHelper(executil.ARGS('git checkout -b ' + branchName));
             }
 
+            print(repo.repoName + ': Update JS snapshot version for VERSION "' + version + '" on branch "' + branchName + '".');
             yield updateJsSnapshot(repo, version, true);
 
             print(repo.repoName + ': Setting VERSION to "' + version + '" on branch "' + branchName + '".');
@@ -235,6 +236,7 @@ exports.prepareReleaseBranchCommand = function * () {
 
             if (platform === 'ios') {
                 // Updates version in CDVAvailability.h file
+                print(repo.repoName + ': Update CDVAvailability.h for VERSION to "' + version + '" on branch "' + branchName + '".');
                 yield updateCDVAvailabilityFile(version);
                 // Git commit changes
                 if (yield gitutil.pendingChangesExist()) {

--- a/src/platform-release.js
+++ b/src/platform-release.js
@@ -142,7 +142,9 @@ function * updateJsSnapshot (repo, version, commit) {
                     // git fetch and update master for cordovajs
                     yield repoupdate.updateRepos([cordovaJsRepo], ['master'], false);
                     yield gitutil.gitCheckout('master');
+                    yield executil.execHelper(executil.ARGS('npm install'), false, true); // WORKAROUND PART 1 for local grunt issue in cordova-js
                     yield executil.execHelper(executil.ARGS('grunt compile:' + repo.id + ' --platformVersion=' + version), false, true);
+                    shelljs.rm('-fr', 'node_modules'); // WORKAROUND PART 2 for local grunt issue in cordova-js
                     hasBuiltJs = version;
                 });
             });

--- a/src/versionutil.js
+++ b/src/versionutil.js
@@ -176,6 +176,6 @@ exports.updateRepoVersion = function * updateRepoVersion (repo, version, opts) {
         var versionDescription = pendingChangesExistInJSON ?
             'version & VERSION' : 'VERSION';
         var pre = opts.pre || '';
-        yield gitutil.commitChanges(pre + 'Set ' + versionDescription + ' to ' + version + ' (via coho)');
+        yield gitutil.commitChanges(pre + 'Set ' + versionDescription + ' to ' + version + ' (coho)');
     }
 };

--- a/src/versionutil.js
+++ b/src/versionutil.js
@@ -86,6 +86,7 @@ exports.getReleaseBranchNameFromVersion = function (version) {
  * @param {Object}  [opts]  An options object
  * @param {Boolean} [opts.commitChanges=true] Specifies whether to commit changes
  *   to the repo after update is done.
+ * @param {String}  [opts.pre=''] Optional commit prefix
  */
 exports.updateRepoVersion = function * updateRepoVersion (repo, version, opts) {
     // Update the VERSION files.
@@ -174,6 +175,7 @@ exports.updateRepoVersion = function * updateRepoVersion (repo, version, opts) {
     if (commitChanges && (yield gitutil.pendingChangesExist())) {
         var versionDescription = pendingChangesExistInJSON ?
             'version & VERSION' : 'VERSION';
-        yield gitutil.commitChanges('Set ' + versionDescription + ' to ' + version + ' (via coho)');
+        var pre = opts.pre || '';
+        yield gitutil.commitChanges(pre + 'Set ' + versionDescription + ' to ' + version + ' (via coho)');
     }
 };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

- fix usage messages
- prepare iOS `CDVAvailability.h` after updating JS in git (more sensical order)
- do not update iOS `CDVAvailability.h` if version number ends with non-numerical character, needed to avoid build error in case of marking -dev version
- workaround for local grunt issue in cordova-js from PR #174 (hope to look into a more "real" solution, someday, will probably comment more in #174)
- Updates to improve support for patch releases (see rationale in PR #176)
  - `prepare-platform-release-branch` add options:
    - `[-b <platform branch name>]`
    - `[-js <cordova-js branch or tag name>]`
  - `copy-js` add option:
    - `[-js <cordova-js branch or tag name>]`
- Add `--tag-only` option to `tag-release ` command (shows the `git push` commands that can be done manually)
- EXTRA GIT WORKAROUND solution to do `git checkout -- package.json`, needed for strange cases with cordova-osx (4.0.2-dev) & cordova-windows
- show slightly modified commit message in case version is updated in package.json
- add `--pre` option to `prepare-platform-release-branch` to allow specific prefix such as JIRA or GH number in the commit messages
- remove some extra info from commit messages
- other minor fixes

This proposal supersedes and resolves #174 (GH-174).

### What testing has been done on this change?

GH-174 was successfully used for a number of patch releases including:
- apache/cordova-browser#55 - CB-14230 patch release 5.0.4
- apache/cordova-osx#51 - CB-14228 release 4.0.2
- apache/cordova-windows#287 - CB-14226 cordova-windows@6.0.1 (July 2018 patch release)
- apache/cordova-ios#381 - CB-14217 cordova-ios 4.5.5 patch release (July 2018)
- apache/cordova-android#467 - CB-14203 patch release
- apache/cordova-osx#50 - CB-14145 resolve npm audit issues in patch fix
- apache/cordova-windows#281 - CB-14145 resolve npm audit issues in patch fix
- apache/cordova-ios#379 - CB-14145 resolve npm audit issues in 4.5.x patch fix
- apache/cordova-android#451 - CB-14145: cordova-common update to resolve npm audit & other updates in patch release
- apache/cordova-browser#53 - CB-14145 resolve npm audit issues in patch release

(updated usage as needed for the patch releases is shown in most of these PRs)

Additional changes to add the `--pre` option & better deal with -dev version are demonstrated working in:

- apache/cordova-ios#387 - CB-14244 start 5.0.0-dev in master branch (includes updated command usage that was used there)

### Checklist

- ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~