### PR TITLE
CB-14249 ensure platform changes are in a dev version (partial workaround doc fix)

### DIFF
--- a/docs/platforms-release-process.md
+++ b/docs/platforms-release-process.md
@@ -33,7 +33,7 @@ It describes the following steps:
 - [Before you start](#before-you-start)
   * [Read through Apache release policy](#read-through-apache-release-policy)
   * [Request buy-in](#request-buy-in)
-  * [Ensure changes are in a dev version](ensure-changes-are-in-a-dev-version)
+  * [Ensure changes are in a dev version](#ensure-changes-are-in-a-dev-version)
 - [Before Release](#before-release)
   * [npm audit check](#npm-audit-check)
   * [Check dependencies](#check-dependencies)

--- a/docs/platforms-release-process.md
+++ b/docs/platforms-release-process.md
@@ -33,6 +33,7 @@ It describes the following steps:
 - [Before you start](#before-you-start)
   * [Read through Apache release policy](#read-through-apache-release-policy)
   * [Request buy-in](#request-buy-in)
+  * [Ensure changes are in a dev version](ensure-changes-are-in-a-dev-version)
 - [Before Release](#before-release)
   * [npm audit check](#npm-audit-check)
   * [Check dependencies](#check-dependencies)
@@ -121,6 +122,10 @@ E.g.:
 Double check you replace "Android" in the subject and mail body - there is no undo for emails.
 
 Note that it would be possible to continue with some of the [Before Release](#before-release) items while waiting for a possible response.
+
+### Ensure changes are in a dev version
+
+The procedure described here may leave non-master branch with a non-dev version number. Functional changes should always be done in a "-dev" version. Please mark the "-dev" version manually or using cordova-coho before making changes, and test it especially when marking "-dev" version manually.
 
 ## Before Release
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

Add section with note to ensure that changes are made in a "-dev" version.

This is a partial workaround for the fundamental issue in [CB-14249](https://issues.apache.org/jira/browse/CB-14249), contributed in response to the discussion in <https://github.com/apache/cordova-android/pull/469>. This kind of workaround was already applied in <https://github.com/apache/cordova-android/pull/470>, <https://github.com/apache/cordova-ios/pull/379>, <https://github.com/apache/cordova-android/pull/454>, and several other places.

I hope we can resolve the inconsistency in release procedure for platforms vs tools described in [CB-14249](https://issues.apache.org/jira/browse/CB-14249) someday, with agreement via <dev@cordova.apache.org>. I cannot promise when I will get a chance to take care of this.

### Merge procedure

- Should be merged by squash (second commit is there to splve a problem with the first commit)

### What testing has been done on this change?

- Quick visual check

### Checklist

- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected. (not true for second commit, which should be squashed anyway)
- ~~Added automated test coverage as appropriate for this change.~~