### PR TITLE
Platform release with npm test section instead of extra unit tests

### DIFF
--- a/docs/platforms-release-process.md
+++ b/docs/platforms-release-process.md
@@ -56,8 +56,6 @@ It describes the following steps:
   * [4) `cordova-lib` tests](#4-cordova-lib-tests)
   * [5) Clean up](#5-clean-up)
   * [Extra Android unit tests](#extra-android-unit-tests)
-  * [Extra iOS unit tests](#extra-ios-unit-tests)
-  * [When a regression is found](#when-a-regression-is-found)
   * [To submit a fix](#to-submit-a-fix)
 - [Push Changes](#push-changes)
   * [Push commits](#push-commits)


### PR DESCRIPTION
was: __Extra Android & iOS unit tests clarification__

because unit tests are already covered by `npm test`

as I discovered in <https://github.com/apache/cordova/issues/54#issuecomment-442457744> and double-checked in my own work area