### PR TITLE
Drop deprecated Node.js 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js: 
-    - "4"
     - "6"
     - "8"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@
 
 environment:
   matrix:
-  - nodejs_version: "4"
   - nodejs_version: "6"
   - nodejs_version: "8"
 


### PR DESCRIPTION
I think no developer will use cordova-coho with Node.js 4.

We should also increase version to 2.0.0-dev if we want to follow semver on this tool.