### PR TITLE
CI testing fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 sudo: false
+
 node_js: 
     - "6"
     - "8"
@@ -7,5 +8,6 @@ node_js:
 
 install: 
     - "npm install"
+
 script:
     - "npm test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 node_js: 
     - "6"
     - "8"
+    - "10"
 
 install: 
     - "npm install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js: 
-    - "4"
     - "6"
     - "8"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
   matrix:
   - nodejs_version: "6"
   - nodejs_version: "8"
+  - nodejs_version: "10"
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@
 
 environment:
   matrix:
-  - nodejs_version: "4"
   - nodejs_version: "6"
   - nodejs_version: "8"
 


### PR DESCRIPTION
* Drop deprecated Node.js 4 support from CI testing (originally proposed in PR #215)
* Add Node.js 10 to CI testing (originally proposed in PR #217)
* .travis.yml add vertical spacing & newline at the end (originally proposed in PR #216)

I think we should also increase version to 2.0.0-dev when we drop Node.js 4 if we want to follow semver on this tool.

This proposal was originally motivated by the spurious AppVeyor failures on Node.js 4 observed in PR #213.

A quick review would be appreciated, would like to merge in a squash commit if there are no major objections.