### PR TITLE
Improvements to src/main.js

### DIFF
--- a/src/check-npm-install-util.js
+++ b/src/check-npm-install-util.js
@@ -1,0 +1,28 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+try {
+    // Ensure npm install has been run.
+    Object.keys(require('../package').dependencies).forEach(require);
+} catch (e) {
+    console.log('Please run "npm install" from this directory:\n\t' + __dirname); // eslint-disable-line no-path-concat
+    process.exit(2);
+}
+
+module.exports = {};

--- a/src/check-npm-install-util.js
+++ b/src/check-npm-install-util.js
@@ -21,7 +21,10 @@ try {
     // Ensure npm install has been run.
     Object.keys(require('../package').dependencies).forEach(require);
 } catch (e) {
-    console.log('Please run "npm install" from this directory:\n\t' + __dirname); // eslint-disable-line no-path-concat
+    const path = require('path'); // Built-in Node.js module
+    console.log(
+       'Please run "npm install" from this directory:\n\t' +
+        path.join(__dirname, '..')); // correct path
     process.exit(2);
 }
 

--- a/src/lazy-require-util.js
+++ b/src/lazy-require-util.js
@@ -1,0 +1,28 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+function * lazyRequire (name, opt_prop) {
+    if (opt_prop) {
+        yield require(name)[opt_prop];
+    } else {
+        yield require(name);
+    }
+}
+
+module.exports = lazyRequire;

--- a/src/main.js
+++ b/src/main.js
@@ -25,11 +25,11 @@ try {
     process.exit(2);
 }
 
-var co = require('co');
-var optimist = require('optimist');
+const co = require('co');
+const optimist = require('optimist');
 
-var executil = require('./executil');
-var apputil = require('./apputil');
+const executil = require('./executil');
+const apputil = require('./apputil');
 
 function * lazyRequire (name, opt_prop) {
     if (opt_prop) {
@@ -40,7 +40,7 @@ function * lazyRequire (name, opt_prop) {
 }
 
 module.exports = function () {
-    var repoCommands = [
+    const repoCommands = [
         {
             name: 'repo-clone',
             desc: 'Clones git repositories as siblings of cordova-coho (unless --no-chdir or --global is used).',
@@ -70,7 +70,8 @@ module.exports = function () {
             desc: 'Update specified git remote to point to corresponding apache github repo',
             entryPoint: lazyRequire('./remote-update')
         }];
-    var releaseCommands = [{
+
+    const releaseCommands = [{
         name: 'prepare-platform-release-branch',
         desc: 'Branches, updates JS, updates VERSION. Safe to run multiple times.',
         entryPoint: lazyRequire('./platform-release', 'prepareReleaseBranchCommand')
@@ -131,7 +132,8 @@ module.exports = function () {
         desc: 'Unpublishes last nightly versions for all specified repositories',
         entryPoint: lazyRequire('./npm-publish', 'unpublishNightly')
     }];
-    var otherCommands = [{
+
+    const otherCommands = [{
         name: 'list-pulls',
         desc: 'Shows a list of GitHub pull requests for all specified repositories.',
         entryPoint: lazyRequire('./list-pulls')
@@ -172,9 +174,9 @@ module.exports = function () {
             console.log(require('../package').version);
             yield Promise.resolve();
         }
-    }
-    ];
-    var commandMap = {};
+    }];
+
+    const commandMap = {};
     function addToCommandMap (cmd) {
         commandMap[cmd.name] = cmd;
     }
@@ -184,7 +186,7 @@ module.exports = function () {
     // aliases:
     commandMap['foreach'] = commandMap['for-each'];
 
-    var usage = 'Usage: $0 command [options]\n\n';
+    let usage = 'Usage: $0 command [options]\n\n';
     function addCommandUsage (cmd) {
         usage += '    ' + cmd.name + ': ' + cmd.desc + '\n';
     }
@@ -204,8 +206,9 @@ module.exports = function () {
     usage += '    ./cordova-coho/coho for-each -r plugins "git clean -fd"\n';
     usage += '    ./cordova-coho/coho last-week --me';
 
-    var command = commandMap[optimist.argv._[0]];
-    var opts = optimist
+    const command = commandMap[optimist.argv._[0]];
+
+    let opts = optimist
         .usage(usage)
         .options('verbose', {
             desc: 'Enable verbose logging',
@@ -233,8 +236,9 @@ module.exports = function () {
             default: true
         });
     }
-    var argv = opts.check(function (argv) {
-        var commandName = argv._[0];
+
+    const argv = opts.check(function (argv) {
+        const commandName = argv._[0];
         if (!commandName) {
             throw 'No command specified.';
         }
@@ -245,13 +249,16 @@ module.exports = function () {
             throw 'No repositories specified, see list-repos';
         }
     }).argv;
+
     if (!command.noChdir) {
         // Change directory to be a sibling of coho.
         apputil.initWorkingDir(argv.chdir);
     }
+
     if (argv.verbose) {
         executil.verbose = true;
     }
-    var entry = command.entryPoint;
+
+    const entry = command.entryPoint;
     co(entry).then();
 };

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ const optimist = require('optimist');
 const executil = require('./executil');
 const apputil = require('./apputil');
 
-const lazyRequire = require('./lazy-require-util.js');
+const lazyRequire = require('./lazy-require-util');
 
 module.exports = function () {
     const repoCommands = [

--- a/src/main.js
+++ b/src/main.js
@@ -17,13 +17,8 @@ specific language governing permissions and limitations
 under the License.
 */
 
-try {
-    // Ensure npm install has been run.
-    Object.keys(require('../package').dependencies).forEach(require);
-} catch (e) {
-    console.log('Please run "npm install" from this directory:\n\t' + __dirname); // eslint-disable-line no-path-concat
-    process.exit(2);
-}
+// Verify that npm install was run before importing anything else
+require('./check-npm-install-util');
 
 const co = require('co');
 const optimist = require('optimist');
@@ -31,13 +26,7 @@ const optimist = require('optimist');
 const executil = require('./executil');
 const apputil = require('./apputil');
 
-function * lazyRequire (name, opt_prop) {
-    if (opt_prop) {
-        yield require(name)[opt_prop];
-    } else {
-        yield require(name);
-    }
-}
+const lazyRequire = require('./lazy-require-util.js');
 
 module.exports = function () {
     const repoCommands = [

--- a/src/main.js
+++ b/src/main.js
@@ -17,17 +17,18 @@ specific language governing permissions and limitations
 under the License.
 */
 
-var executil = require('./executil');
-
 try {
-    var co = require('co');
-    var optimist = require('optimist');
     // Ensure npm install has been run.
     Object.keys(require('../package').dependencies).forEach(require);
 } catch (e) {
     console.log('Please run "npm install" from this directory:\n\t' + __dirname); // eslint-disable-line no-path-concat
     process.exit(2);
 }
+
+var co = require('co');
+var optimist = require('optimist');
+
+var executil = require('./executil');
 var apputil = require('./apputil');
 
 function * lazyRequire (name, opt_prop) {


### PR DESCRIPTION
* Check that npm dependencies are present before other require declarations in `src/main.js`
* Move code to check npm dependencies to `src/check-npm-install-util.js` utility module
* define `lazyRequire` in `src/lazy-require-util.js`
* `var` -> `const` / `let` in `main.js`, with vertical space added before some of the `const` & `let` declarations
* fix to show correct path to run "npm install", if npm dependencies are not present

Before these changes, running `cordova-coho/coho` without running `npm install` would result in the following error output:
```
internal/modules/cjs/loader.js:582
    throw err;
    ^

Error: Cannot find module 'chalk'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:580:15)
    at Function.Module._load (internal/modules/cjs/loader.js:506:25)
    at Module.require (internal/modules/cjs/loader.js:636:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/Users/brodybits/Documents/cordova/cordova-coho/src/apputil.js:21:13)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
```