### PR TITLE
Clarify working directory (-g etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To see valid repo ids and repo group ids for use with Coho, use the `list-repos`
 
 ### Note about global context
 
-Note that for some commands you may need to use the `-g` or `--global` flag to work in an npm global context, since coho was originally designed for use in another context.
+By default `coho` is executed in the parent of where it is installed or checked out (since coho was originally designed for use in another context where this was needed). To work in a global context, meaning the current folder where you are executing `coho`, most commands require you to use the `-g` or `--global` flag. To make this more obvious, all commands first output their current working directory: `Running from ...`.
 
 ## Contributing
 

--- a/src/apputil.js
+++ b/src/apputil.js
@@ -34,7 +34,7 @@ exports.initWorkingDir = function (chdir) {
         process.chdir(newDir);
         baseWorkingDir = newDir;
     }
-    console.log('Running from ' + baseWorkingDir);
+    console.log('Running from ' + baseWorkingDir + ' (use `-g` to run in current working directory)');
 };
 
 exports.getBaseDir = function () {

--- a/src/main.js
+++ b/src/main.js
@@ -247,7 +247,10 @@ module.exports = function () {
     if (!command.noChdir) {
         // Change directory to be a sibling of coho.
         apputil.initWorkingDir(argv.chdir);
+    } else {
+        console.log('Running from ' + apputil.getBaseDir());
     }
+
     if (argv.verbose) {
         executil.verbose = true;
     }


### PR DESCRIPTION
One of the more confusing aspects of coho is that by default it runs in the parent directory of the coho install/checkout. This PR adds more output and updates the README to make this more discoverable.