### PR TITLE
Platform Release Docs: repleace JIRA with release identifier

### DIFF
--- a/docs/platforms-release-process.md
+++ b/docs/platforms-release-process.md
@@ -32,13 +32,13 @@ It describes the following steps:
   * [Repository setup](#repository-setup)
 - [Before you start](#before-you-start)
   * [Read through Apache release policy](#read-through-apache-release-policy)
+  * [Choose a Release Identifier](#choose-a-release-identifier)
   * [Request buy-in](#request-buy-in)
 - [Before Release](#before-release)
   * [npm audit check](#npm-audit-check)
   * [Check dependencies](#check-dependencies)
   * [Resolve any outdated dependencies](#resolve-any-outdated-dependencies)
   * [License Check](#license-check)
-  * [Create JIRA issue](#create-jira-issue)
 - [Prepare Release](#prepare-release)
   * [Optional: Set release version in `package.json`](#optional-set-release-version-in-packagejson)
     - [Remove the `-dev` suffix from version](#remove-the--dev-suffix-from-version)
@@ -75,7 +75,6 @@ It describes the following steps:
   * [Tell Apache about Release](#tell-apache-about-release)
   * [Email a release announcement to the mailing list](#email-a-release-announcement-to-the-mailing-list)
   * [Announce It!](#announce-it)
-  * [Close JIRA issue](#close-jira-issue)
   * [Finally](#finally)
 - [Other stuff that should be reviewed and moved up to the appropriate places](#other-stuff-that-should-be-reviewed-and-moved-up-to-the-appropriate-places)
   * [Update the Docs](#update-the-docs)
@@ -103,6 +102,18 @@ You should have your platform repository checked out in a folder where you also 
 ### Read through Apache release policy
 
 Read through the [Apache Releases Policy](http://www.apache.org/dev/release) as stated above. 
+### Choose a Release Identifier
+
+Releases are identified by a "Release Identifier" that is used in commit messages and for temporary folders. 
+
+Good choices are unique and have a direct relation to the release you are about to perform. Examples for valid identifiers would be `android20190506` or `android@503`. You can also create a release issue and use that (including the repository name): `cordova-android#123`.
+
+You set it similar to the active plugins:
+
+```
+RELEASE=android20190506
+echo $RELEASE
+```
 
 ### Request buy-in
 
@@ -146,11 +157,11 @@ See if any dependencies are outdated
 **Alternative 1:**
 
 - Explicitly pin the outdated dependency versions in the `dependencies` section of `package.json`.
-- Raise a new JIRA issue to update the dependencies in an upcoming release.
+- Raise a new issue to update the dependencies in an upcoming release.
 
 **Alternative 2:**
 
-Within a new JIRA issue: update any outdated dependencies in the project's `package.json` file. Be sure to run through the test section below for compatibility issues.
+Within a new Pull Request: update any outdated dependencies in the project's `package.json` file. Be sure to run through the test section below for compatibility issues.
 
 ### License Check
 
@@ -162,21 +173,6 @@ Ensure all dependencies and subdependencies have Apache-compatible licenses.
 
     coho check-license -r android
 
-### Create JIRA issue
-
-After waiting for any possible objections from the email sent according to the [Request buy-in](#request-buy-in) section above:
-
- * Create a JIRA issue to track the status of the release.
-   - Make it of type "Task"
-   - Title should be "Cordova-Android Platform Release _August 21, 2014_"
-   - Description should be: "Following steps at https://github.com/apache/cordova-coho/blob/master/docs/platforms-release-process.md"
- * Comments should be added to this bug after each top-level step below is taken
- * Set a variable in your terminal for use later on
-
-
-```
-JIRA="CB-????" # Set this to the release bug.
-```
 
 ## Prepare Release
 
@@ -222,9 +218,9 @@ or use your favorite text editor manually.
 
 Commit these changes together in a single commit (one commit).
 
-    (cd cordova-android && v="$(grep '"version"' package.json | cut -d'"' -f4)" && git commit -am "$JIRA Update RELEASENOTES & version for release $v")
+    (cd cordova-android && v="$(grep '"version"' package.json | cut -d'"' -f4)" && git commit -am "Update RELEASENOTES & version for release $v ($RELEASE)")
 
-(Should be "$JIRA Update RELEASENOTES.md for release $v" in case `version` is not yet updated in `package.json`.)
+(Should be `Update RELEASENOTES.md for release $v ($RELEASE)` in case `version` is not yet updated in `package.json`.)
 
 ### Special Case 1: Release notes in release branch for patch release
 
@@ -246,7 +242,7 @@ Create and prepare your release branch by using `coho prepare-platform-release-b
 1. Creates a release branch `5.0.x` (if it doesn't already exist)
 2. Updates `cordova.js` snapshot on both `5.0.x` and `master`
 3. Propagates version number from `--version` argument (or from `package.json` if there is no `--version` argument) to all other files (`VERSION` and similar [e.g. `build.gradle` for Android]) on the release branch `5.0.x`
-4. Prepares `master` for future development already: It gives version (`package.json`, `VERSION` and similar) a minor bump and adds `-dev` (=> `5.1.0-dev`) again
+4. Prepares `master` for future development already: It gives version (`package.json`, `VERSION` and similar) a minor bump and adds `-dev` (=> `5.1.0-dev`) back
 
 Run the following command (make sure to replace the version below with what is listed inside `package.json`).
 
@@ -322,7 +318,7 @@ rm -rf androidTest*
 
 ### When a regression is found
 
-Create a JIRA issue for it, and mark it as a blocker.
+Create an issue for it and fix it via a Pull Request before continuing.
 
 ### To submit a fix
 
@@ -372,15 +368,15 @@ Ensure you have the svn repos checked out:
 
 Create archives from your tags:
 
-    coho create-archive -r android --dest cordova-dist-dev/$JIRA --tag 5.0.0
+    coho create-archive -r android --dest cordova-dist-dev/$RELEASE --tag 5.0.0
 
 Sanity Check:
 
-    coho verify-archive cordova-dist-dev/$JIRA/*.tgz
+    coho verify-archive cordova-dist-dev/$RELEASE/*.tgz
 
 Upload:
 
-    (cd cordova-dist-dev && svn add $JIRA && svn commit -m "$JIRA Uploading release candidates for android release")
+    (cd cordova-dist-dev && svn add $RELEASE && svn commit -m "Uploading release candidates for android release ($RELEASE)")
 
 If everything went well the Release Candidate will show up here: https://dist.apache.org/repos/dist/dev/cordova/
 
@@ -414,10 +410,8 @@ __Body:__
     Please review and vote on this 5.0.0 Android Release
     by replying to this email (and keep discussion on the DISCUSS thread)
 
-    Release issue: https://issues.apache.org/jira/browse/CB-XXXX
-
     The archive has been published to dist/dev:
-    https://dist.apache.org/repos/dist/dev/cordova/CB-XXXX
+    https://dist.apache.org/repos/dist/dev/cordova/XXX/
 
     The package was published from its corresponding git tag:
     ### PASTE OUTPUT OF: coho print-tags -r android --tag 5.0.0 ###
@@ -484,9 +478,9 @@ First move the release package files to `dist/`:
     cd cordova-dist
     svn up
     svn rm platforms/cordova-android*
-    cp ../cordova-dist-dev/$JIRA/cordova-android* platforms/
+    cp ../cordova-dist-dev/$RELEASE/cordova-android* platforms/
     svn add platforms/cordova-android*
-    svn commit -m "$JIRA Published android release to dist"
+    svn commit -m "Published android release to dist ($RELEASE)"
 
 Now you can find your release here: https://dist.apache.org/repos/dist/release/cordova/
 
@@ -494,11 +488,11 @@ Then you can also remove the release candidate from `dist-dev/`:
 
     cd ../cordova-dist-dev
     svn up
-    svn rm $JIRA
-    svn commit -m "$JIRA Removing release candidates from dist/dev"
+    svn rm $RELEASE
+    svn commit -m "Removing release candidates from dist/dev ($RELEASE)"
     cd ..
 
-And finally you can publish your package to `npm`:
+And finally you can publish your package to npm:
 
     cd cordova-dist
     npm publish platforms/cordova-android-5.0.0.tgz
@@ -559,11 +553,6 @@ Announce the release to the world!
 * Publish the release blog post
 * Tweet it on https://twitter.com/apachecordova
    
-### Close JIRA Issue
-
-- Double check that the issue includes comments that record the steps you took
-- Mark it as fixed
-
 ### Finally
 
 - Update these instructions if they were missing anything.

--- a/docs/platforms-release-process.md
+++ b/docs/platforms-release-process.md
@@ -21,23 +21,21 @@
 
 # Release Process for Cordova Platforms
 
-This page describes the technical steps for doing a `Platforms Release`.
+This page describes the technical steps for doing a Platforms Release.
 
 ## Table of contents
-
-It describes the following steps:
 
 - [General instructions](#general-instructions)
   * [Read first](#read-first)
   * [Repository setup](#repository-setup)
 - [Before you start](#before-you-start)
-  * [Read through Apache release policy](#read-through-apache-release-policy)
   * [Choose a Release Identifier](#choose-a-release-identifier)
   * [Request buy-in](#request-buy-in)
 - [Before Release](#before-release)
-  * [npm audit check](#npm-audit-check)
+  * [Make sure you're up-to-date](#make-sure-youre-up-to-date)
   * [Check dependencies](#check-dependencies)
-  * [Resolve any outdated dependencies](#resolve-any-outdated-dependencies)
+    - [Resolve any outdated dependencies](#resolve-any-outdated-dependencies)
+  * [`npm audit` check](#npm-audit-check)
   * [License Check](#license-check)
 - [Prepare Release](#prepare-release)
   * [Optional: Set release version in `package.json`](#optional-set-release-version-in-packagejson)
@@ -56,7 +54,7 @@ It describes the following steps:
   * [4) `cordova-lib` tests](#4-cordova-lib-tests)
   * [5) Clean up](#5-clean-up)
   * [When a regression is found](#when-a-regression-is-found)
-  * [To submit a fix](#to-submit-a-fix)
+    - [To submit a fix](#to-submit-a-fix)
 - [Push Changes](#push-changes)
   * [Push commits](#push-commits)
   * [Tag and push tag](#tag-and-push-tag)
@@ -68,7 +66,7 @@ It describes the following steps:
   * [Start VOTE Thread](#start-vote-thread)
   * [Email the result of the vote](#email-the-result-of-the-vote)
   * [If the Vote does *not* Pass](#if-the-vote-does-not-pass)
-  * [Otherwise: Publish real release to `dist/` & npm](#otherwise-publish-real-release-to-dist--npm)
+  * [Otherwise: Publish release to `dist/` & npm](#otherwise-publish-release-to-dist--npm)
   * [(Android only) Uploading to Bintray](#android-only-uploading-to-bintray)
   * [Add permanent Apache release tag to repository](#add-permanent-apache-release-tag-to-repository)
 - [Follow up steps](#follow-up-steps)
@@ -82,7 +80,6 @@ It describes the following steps:
     
 <!-- created with https://ecotrust-canada.github.io/markdown-toc/ and some manual fixing -->
 
-(Yes this list is long and scary, but represents the content below)
 
 ## General instructions
 
@@ -97,11 +94,10 @@ It describes the following steps:
 You should have your platform repository checked out in a folder where you also have checked out all/most/some of the other Cordova repositories. If you followed the [Cloning/Updating Cordova repositories
 ](../README.md#cloningupdating-cordova-repositories) instructions of `cordova-coho`, this should already be the case.
 
+
 ## Before you start
 
-### Read through Apache release policy
 
-Read through the [Apache Releases Policy](http://www.apache.org/dev/release) as stated above. 
 ### Choose a Release Identifier
 
 Releases are identified by a "Release Identifier" that is used in commit messages and for temporary folders. 
@@ -132,19 +128,16 @@ Double check you replace "Android" in the subject and mail body - there is no un
 
 Note that it would be possible to continue with some of the [Before Release](#before-release) items while waiting for a possible response.
 
+
 ## Before Release
 
-### npm audit check
-
-Ensure that the latest version of npm is installed (using a command such as `npm i npm@latest`), `package-lock.json` is present (do `npm i --package-lock-only` if needed), and then check:
-
-    (cd cordova-android && npm audit)
-
-### Check dependencies
+### Make sure you're up-to-date
 
 Ensure your checkout of the repository is up-to-date:
 
-    coho repo-update -r android
+    coho repo-update -r android   # updates the repos
+
+### Check dependencies
 
 See if any dependencies are outdated
 
@@ -152,7 +145,7 @@ See if any dependencies are outdated
 
 (The `--depth=0` prevents from listing dependencies of dependencies.)
 
-### Resolve any outdated dependencies
+#### Resolve any outdated dependencies
 
 **Alternative 1:**
 
@@ -162,6 +155,14 @@ See if any dependencies are outdated
 **Alternative 2:**
 
 Within a new Pull Request: update any outdated dependencies in the project's `package.json` file. Be sure to run through the test section below for compatibility issues.
+
+### `npm audit` check
+
+Ensure that the latest version of npm is installed (using a command such as `npm i npm@latest`), `package-lock.json` is present (do `npm i --package-lock-only` if needed), and then check:
+
+    (cd cordova-android && npm audit)
+
+TODO Get rid of package-lock.json afterwards
 
 ### License Check
 
@@ -207,6 +208,7 @@ Update the repos `RELEASENOTES.md` file with changes since the last release.
     coho update-release-notes -r android
 
 (`--from-tag` and/or `--to-tag` may be needed in case of non-master branch)
+TODO what does that mean? Examples.
 
 Then curate:
 
@@ -320,7 +322,7 @@ rm -rf androidTest*
 
 Create an issue for it and fix it via a Pull Request before continuing.
 
-### To submit a fix
+#### To submit a fix
 
     git checkout master
     git commit -am 'Your commit message'
@@ -466,10 +468,11 @@ _Note: list of PMC members: http://people.apache.org/phonebook.html?pmc=cordova_
 * Revert adding of `-dev`
 * Address the concerns
 * Re-tag release using `git tag -f`
+TODO this seems to be missing a few steps here
 * Add back `-dev`
 * Start a new vote
 
-### Otherwise: Publish real release to `dist/` & npm
+### Otherwise: Publish release to `dist/` & npm
 
 First move the release package files to `dist/`:
 

--- a/docs/platforms-release-process.md
+++ b/docs/platforms-release-process.md
@@ -104,7 +104,7 @@ Releases are identified by a "Release Identifier" that is used in commit message
 
 Good choices are unique and have a direct relation to the release you are about to perform. Examples for valid identifiers would be `android20190506` or `android@503`. You can also create a release issue and use that (including the repository name): `cordova-android#123`.
 
-You set it similar to the active plugins:
+Then set it as an environment variable:
 
 ```
 RELEASE=android20190506


### PR DESCRIPTION
This PR removes the outdated JIRA stuff and rpelaces it with a new release identifier. 
(It also does some general light cleanup)