### PR TITLE
apache-rat-0.13 download update

### DIFF
--- a/src/audit-license-headers.js
+++ b/src/audit-license-headers.js
@@ -53,8 +53,8 @@ var COMMON_RAT_EXCLUDES = [
 var RAT_IGNORE_PATH = '.ratignore';
 var RATIGNORE_COMMENT_PREFIX = '#';
 
-var RAT_NAME = 'apache-rat-0.12';
-var RAT_URL = 'https://dist.apache.org/repos/dist/release/creadur/apache-rat-0.12/apache-rat-0.12-bin.tar.gz';
+var RAT_NAME = 'apache-rat-0.13';
+var RAT_URL = 'https://dist.apache.org/repos/dist/release/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz';
 
 function startsWith (string, prefix) {
     return string.indexOf(prefix) === 0;


### PR DESCRIPTION
with updated download link

P.S. The motivation is that the old apache-rat-0.12 download link did not seem to work.