### PR TITLE
fix(audit-license-headers): broken exclusion patterns

### DIFF
--- a/src/audit-license-headers.js
+++ b/src/audit-license-headers.js
@@ -53,8 +53,8 @@ var COMMON_RAT_EXCLUDES = [
 var RAT_IGNORE_PATH = '.ratignore';
 var RATIGNORE_COMMENT_PREFIX = '#';
 
-var RAT_NAME = 'apache-rat-0.13';
-var RAT_URL = 'https://dist.apache.org/repos/dist/release/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz';
+var RAT_NAME = 'apache-rat-0.12';
+var RAT_URL = 'https://archive.apache.org/dist/creadur/apache-rat-0.12/apache-rat-0.12-bin.tar.gz';
 
 function startsWith (string, prefix) {
     return string.indexOf(prefix) === 0;


### PR DESCRIPTION
This reverts the Apache RAT upgrade from v0.12 to v0.13 (see #246). This is necessary due to a bug in the file exclusion logic of RAT v0.13.

For more details see: https://issues.apache.org/jira/browse/RAT-265

Closes #247