### PR TITLE
fix(audit-license-headers): RAT tool download on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "co": "~4.0",
     "co-stream": "0.1.1",
     "glob": "^5.0.14",
+    "got": "^9.6.0",
     "inquirer": "2.0.0",
     "jira-client": "4.2.0",
     "jira-linkify": "^2.3.0",
@@ -21,6 +22,7 @@
     "request": "^2.88.0",
     "semver": "^4.2.0",
     "shelljs": "0.1.4",
+    "tar-fs": "^2.0.0",
     "treeify": "^1.0.1",
     "xml2js": "0.4.17"
   },

--- a/spec/audit-license-headers.spec.js
+++ b/spec/audit-license-headers.spec.js
@@ -1,0 +1,36 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+require('jasmine-co').install();
+const path = require('path');
+const shell = require('shelljs');
+const repoutil = require('../src/repoutil');
+const auditLicenseHeaders = require('../src/audit-license-headers');
+
+describe('audit-license-headers', () => {
+    describe('scrubRepos', () => {
+        it('basic operation', function * () {
+            spyOn(console, 'log');
+            shell.rm('-rf', path.join(__dirname, '../apache-rat-*'));
+
+            const cohoRepo = repoutil.getRepoById('coho');
+            yield auditLicenseHeaders.scrubRepos([cohoRepo], true);
+        });
+    });
+});


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Needs #258, fixes #240


### Description
<!-- Describe your changes in detail -->
Downloads and extracts Apache RAT using Node.js libraries instead of
unix-specific CLI utilities.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I've added a smoke test for the `audit-license-headers` module. CI passes on Windows.
