### PR TITLE
chore: require at least Node.js v4

### DIFF
--- a/coho
+++ b/coho
@@ -18,14 +18,4 @@ specific language governing permissions and limitations
 under the License.
 */
 
-try {
-    eval('(function*(){})');
-} catch (e) {
-    try {
-        require('gnode'); // Enable generators support
-    } catch (e) {
-        console.log('Please run "npm install" from this directory:\n\t' + __dirname);
-        process.exit(2);
-    }
-}
 require('./src/main')();

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "co": "~4.0",
     "co-stream": "0.1.1",
     "glob": "^5.0.14",
-    "gnode": "^0.1.0",
     "inquirer": "2.0.0",
     "jasmine": "^2.5.3",
     "jasmine-co": "^1.2.2",
@@ -58,5 +57,8 @@
     "steven gill",
     "Brian LeRoux"
   ],
+  "engines": {
+    "node": ">=4"
+  },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
This allows us to drop the dependency on `gnode`.