### PR TITLE
fix(gitutil): do not stash ignored files

### DIFF
--- a/src/gitutil.js
+++ b/src/gitutil.js
@@ -119,7 +119,7 @@ exports.stashAndPop = function * (repo, func) {
     var branchName = yield gitutil.retrieveCurrentBranchName();
 
     if (requiresStash) {
-        yield executil.execHelper(executil.ARGS('git stash save --all --quiet', 'coho stash'));
+        yield executil.execHelper(executil.ARGS('git stash save --include-untracked --quiet', 'coho stash'));
     }
 
     yield func();


### PR DESCRIPTION
Until now `gitutil.stashAndPop` ran the following command for each repo:

    git stash save --all --quiet "coho stash"

Beside changed and untracked files, this also stashes ignored files. In
our case that includes the `node_modules` folder. Due to the massive
amount of files in there, that command takes a decent amount of time and
can also lead to _a lot_ of CRLF warning messages, depending on your
local git configuration.

Furthermore, the new build system of `cordova-js` needs to have its
dependencies present to be able to run. But since the `cordova-js` build
is run in a `stashAndPop` block, all modules have been stashed and thus
the build always fails.

AFAICT, no invocation of `gitutil.stashAndPop` does actually _need_ to
stash ignored files. Thus we can resolve these issues by replacing the
`--all` flag with `--include-untracked`, giving us this command:

    git stash save --include-untracked --quiet "coho stash"

This safely stashes all content that could potentially be destroyed by
`coho` operations, while leaving ignored files in place.
