### PR TITLE
change repo-clone from https to ssh

### DIFF
--- a/src/repo-clone.js
+++ b/src/repo-clone.js
@@ -45,7 +45,7 @@ module.exports = function * (_argv) {
 };
 
 function createRepoUrl (repo) {
-    return 'https://github.com/apache/' + repo.repoName + '.git';
+    return 'git@github.com:apache/' + repo.repoName + '.git';
 }
 
 function * cloneRepos (repos, quiet, depth) {


### PR DESCRIPTION
Up for discussion if cloning via https should be changed

[See question here](https://lists.apache.org/thread.html/c2083866aa57caec341b735b9baef661b33208b14cdb3d85f351fd85%40%3Cdev.cordova.apache.org%3E)