### PR TITLE
Improve gpg fingerprint documentation

### DIFF
--- a/docs/setting-up-gpg.md
+++ b/docs/setting-up-gpg.md
@@ -112,7 +112,13 @@ Copy to your Apache homedir:
     gpg --armor --export $KEY_ID > $KEY_ID.asc
     scp $KEY_ID.asc people.apache.org:
 
-#### Optional
+#### Fingerprint
+
+**Recommended** to make it easier for other PMC members to check dist archives:
+
+Here is a quick command to show your gpg key fingerprint:
+
+    gpg --fingerprint
 
 Sign into: https://id.apache.org/ and add your fingerprint (not your KEY_ID). This will cause emails from Apache to you to be encrypted.
 


### PR DESCRIPTION
- Add `Fingerprint` sub header (H3)
- Recommended rather than optional
- Add quick command to get the gpg fingerprint

P.S. This proposal was triggered by [this email on the dev mailing list](https://lists.apache.org/thread.html/6f6c96f0bf9f4c4213e19a58a7d190e707d9ec98e87f15316203bfc4%40%3Cdev.cordova.apache.org%3E)