### PR TITLE
build(deps): updates Apache Rat from 0.12 to 0.13

### DIFF
--- a/src/audit-license-headers.js
+++ b/src/audit-license-headers.js
@@ -90,7 +90,7 @@ module.exports.scrubRepos = function * (repos, silent, ignoreError, win, fail) {
 
 // Returns path to Apache RAT JAR; downloads it first if necessary
 async function getRatJar () {
-    const RAT_ID = 'apache-rat-0.12';
+    const RAT_ID = 'apache-rat-0.13';
     const RAT_URL = `https://archive.apache.org/dist/creadur/${RAT_ID}/${RAT_ID}-bin.tar.gz`;
 
     const cohoRoot = repoutil.getRepoDir(repoutil.getRepoById('coho'));


### PR DESCRIPTION
### Motivation and Context

Updates Rat to 0.13 - the old 0.12 URL results in a 404 (https://dist.apache.org/repos/dist/release/creadur/apache-rat-0.12/apache-rat-0.12-bin.tar.gz).