### PR TITLE
chore: add license header & enable npm verbose always

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Cordova Nightly
 
 on:
@@ -9,7 +26,7 @@ on:
         default: 'Re-run broken nightly build'
 
       verbose:
-        description: 'Enable Verbose'
+        description: 'Enable Coho Verbose'
         required: true
         default: 'false'
 
@@ -22,6 +39,8 @@ jobs:
 
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Since npm loglevel is not boolean, it will always be in verbose mode to better debug errors.
+      npm_config_loglevel: verbose
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
* Add apache license header to yaml file.
* Always have npm verbose enabled.