### PR TITLE
ci: disable nightly on forks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,8 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'apache/cordova-coho'
+
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
### Motivation and Context

Saw nightly try to run off my fork so updating the config to check against the repo that triggered the action.