### PR TITLE
chore: bump actions/setup-node@v2.1.2

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2.1.1
+      - uses: actions/setup-node@v2.1.2
         with:
           node-version: 14.x
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
### Motivation, Context & Description

Bump the setup-node dependency to latest version. 

This might be the solution to resolve the failed nightly builds. The failures are originating from the dependency.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ 
