### PR TITLE
cleanup: remove updating version from framework build.gradle

### DIFF
--- a/spec/versionutil.spec.js
+++ b/spec/versionutil.spec.js
@@ -85,9 +85,7 @@ describe('versionutil', function () {
         setupPlatform('android');
         yield versionutil.updateRepoVersion(androidRepo, testVersion);
         expectTestVersioninFiles(
-            'bin/templates/cordova/version',
-            'framework/src/org/apache/cordova/CordovaWebView.java',
-            'framework/build.gradle'
+            'framework/src/org/apache/cordova/CordovaWebView.java'
         );
     });
 

--- a/src/versionutil.js
+++ b/src/versionutil.js
@@ -117,11 +117,8 @@ exports.updateRepoVersion = function * updateRepoVersion (repo, version, opts) {
 
         if (repo.id === 'android') {
             shelljs.sed('-i', /CORDOVA_VERSION.*=.*;/, 'CORDOVA_VERSION = "' + version + '";', path.join('framework', 'src', 'org', 'apache', 'cordova', 'CordovaWebView.java'));
-            // Set build.gradle version, vcsTag, and name
-            shelljs.sed('-i', /version.*=.*/, "version = '" + version + "'", path.join('framework', 'build.gradle'));
-            shelljs.sed('-i', /vcsTag.*=.*/, "vcsTag = '" + version + "'", path.join('framework', 'build.gradle'));
-            shelljs.sed('-i', /version.{\n.*(name.*=.*)/, "version {\n            name = '" + version + "'", path.join('framework', 'build.gradle'));
         }
+
         shelljs.config.fatal = false;
 
         if (!(yield gitutil.pendingChangesExist())) {


### PR DESCRIPTION
### Platforms affected

android

### Motivation, Context & Description

This PR removes the updating of Android version info from framework build.gradle.
Version info is not stored in this location anymore.

This is preperation for Cordova-Android 10 release. If there is ever a need to release on Cordova-Android 9.x or ealier, use branch `coho-20210714`.

### Testing

- none

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
