### PR TITLE
fix(nightly): npm install before publish for cordova-electron's js build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -143,6 +143,7 @@ jobs:
       - name: NPM Publish - cordova-electron
         run: |
           cd ../cordova-electron
+          npm i
           npm publish --tag nightly
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Motivation, Context & Description

Nightly is failing to publish Cordova-Electron because of the new npm prepare-hook scrip that automates the building of the `cordova-js` during release.

`npm i` must be performed before `npm publish`.

Other platforms will need this change in the future once the cordova-js's new build process is added.

### Testing

- n/a