### PR TITLE
fix(nightly): npm install before publish for cordova-ios's js build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -151,6 +151,7 @@ jobs:
       - name: NPM Publish - cordova-ios
         run: |
           cd ../cordova-ios
+          npm i
           npm publish --tag nightly
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Motivation, Context & Description

Nightly is failing to publish Cordova-iOS because of the new npm prepare-hook scrip that automates the building of the `cordova-js` during release.

`npm i` must be performed before `npm publish`.

Other platforms will need this change in the future once the cordova-js's new build process is added.

### Testing

- n/a