### PR TITLE
fix: Ignore codecov files

### DIFF
--- a/src/audit-license-headers.js
+++ b/src/audit-license-headers.js
@@ -43,6 +43,10 @@ const COMMON_RAT_EXCLUDES = [
     '*-Info.plist',
     'Info.plist',
 
+    // exclude code coverage reports
+    'lcov-*',
+    'lcov.info',
+
     // Other
     '.*',
     '*.json', // Excludes all JSON files because commenting is not supported.


### PR DESCRIPTION
Ignores coverage/ files

I opted to not use `coverage` as the exclude term, as I felt that's too generic/broad and may potentially exclude files that we would want to scan.

The RAT tool also doesn't appear to support a full glob syntax, so doing something like `coverage/**` doesn't work.

So finally I choose `lcov-*` and `lcov.info`, which I feel is the safest exclude terms.

These are generated files by code coverage tools and RAT states:

> Generated files do not require license headers.

Yet these files were being checked and was creating unnecessary noise.